### PR TITLE
[#11] US2/US3 누락 테스트 보완 + metrics 서비스 분리

### DIFF
--- a/specs/001-activity-focus-tracker/tasks.md
+++ b/specs/001-activity-focus-tracker/tasks.md
@@ -84,9 +84,9 @@
 
 ### 테스트 먼저 작성 (Red) ⚠️
 
-- [ ] T028 [P] [US2] `src/__tests__/components/DonutChart.test.tsx` 작성: `{ focus: 60, neutral: 20, distraction: 20 }` 데이터로 차트 렌더링 확인, 0% 일 때 빈 상태 렌더링 테스트
-- [ ] T029 [P] [US2] `src/__tests__/components/Dropdown.test.tsx` 작성: `mockIPC()` 사용, 세션 없을 때/있을 때 렌더링 테스트
-- [ ] T030 [P] [US2] 기존 테스트 항목 — 통합 테스트로 대체 가능 (선택적)
+- [x] T028 [P] [US2] `src/__tests__/components/DonutChart.test.tsx` 작성: 렌더링, 0% 빈 상태, 100% focus, size prop 테스트 (6개 테스트)
+- [x] T029 [P] [US2] `src/__tests__/components/Dropdown.test.tsx` 작성: `mockIPC()` 사용, 세션 없을 때/있을 때, 복구 팝업, 세션 시작, 도넛 차트, 앱 리스트, Dashboard 버튼 테스트 (7개 테스트)
+- [x] T030 [P] [US2] 통합 테스트로 대체 완료
 
 ### 구현 (Green) ✅ 완료
 
@@ -112,8 +112,8 @@
 
 ### 테스트 먼저 작성 (Red) ⚠️
 
-- [ ] T039 [P] [US3] `src-tauri/src/services/metrics.rs` 내 `#[cfg(test)]` 블록 작성: focus 60s + neutral 30s + distraction 30s → 각 퍼센트 50%, 25%, 25%, 합 100% 테스트; total_secs=0 → 모든 퍼센트 0.0 테스트
-- [ ] T040 [P] [US3] `src-tauri/tests/metrics_tests.rs` 작성: `get_focus_metrics` 커맨드 통합 테스트 — 여러 활동 저장 후 메트릭 조회
+- [x] T039 [P] [US3] `src-tauri/src/services/metrics.rs` 신규 생성 + `#[cfg(test)]` 단위 테스트: 빈 세션, 활동 집계, 퍼센트 합 100%, top_apps 정렬/퍼센트/분류 (6개 단위 테스트)
+- [x] T040 [P] [US3] `src-tauri/tests/metrics_tests.rs` 통합 테스트: 복수 분류, 세션 격리, total_secs, 10개 제한, 동일 앱 합산, 퍼센트 합 100% (6개 통합 테스트)
 
 ### 구현 (Green)
 

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -3,7 +3,7 @@ use tauri::{AppHandle, State};
 
 use crate::errors::AppError;
 use crate::models::session::{Session, SessionStatus};
-use crate::services::{session as session_svc, tracker};
+use crate::services::{metrics as metrics_svc, session as session_svc, tracker};
 use crate::state::app_state::AppState;
 
 #[derive(Debug, serde::Serialize)]
@@ -214,51 +214,13 @@ pub async fn get_focus_stats(
         let state = state.lock().map_err(|e| AppError::Internal(e.to_string()))?;
         state.db_pool.clone()
     };
-    let conn = pool.get().map_err(AppError::from)?;
-
-    let started_at: i64 = conn
-        .query_row(
-            "SELECT started_at FROM sessions WHERE id = ?1",
-            rusqlite::params![session_id],
-            |r| r.get(0),
-        )
-        .map_err(AppError::from)?;
-
-    let now = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs() as i64;
-    let total_secs = (now - started_at).max(0);
-
-    let mut stmt = conn
-        .prepare(
-            "SELECT classification, COALESCE(SUM(duration_secs), 0)
-             FROM activities WHERE session_id = ?1
-             GROUP BY classification",
-        )
-        .map_err(AppError::from)?;
-
-    let mut focus_secs = 0i64;
-    let mut neutral_secs = 0i64;
-    let mut distraction_secs = 0i64;
-
-    let rows = stmt
-        .query_map(rusqlite::params![session_id], |r| {
-            Ok((r.get::<_, String>(0)?, r.get::<_, i64>(1)?))
-        })
-        .map_err(AppError::from)?;
-
-    for row in rows {
-        let (cls, secs) = row.map_err(AppError::from)?;
-        match cls.as_str() {
-            "Focus" => focus_secs = secs,
-            "Neutral" => neutral_secs = secs,
-            "Distraction" => distraction_secs = secs,
-            _ => {}
-        }
-    }
-
-    Ok(FocusStats { total_secs, focus_secs, neutral_secs, distraction_secs })
+    let svc = metrics_svc::query_focus_stats(&pool, &session_id)?;
+    Ok(FocusStats {
+        total_secs: svc.total_secs,
+        focus_secs: svc.focus_secs,
+        neutral_secs: svc.neutral_secs,
+        distraction_secs: svc.distraction_secs,
+    })
 }
 
 #[tauri::command]
@@ -270,52 +232,16 @@ pub async fn get_top_apps(
         let state = state.lock().map_err(|e| AppError::Internal(e.to_string()))?;
         state.db_pool.clone()
     };
-    let conn = pool.get().map_err(AppError::from)?;
-
-    let total_secs: i64 = conn
-        .query_row(
-            "SELECT COALESCE(SUM(duration_secs), 0) FROM activities WHERE session_id = ?1",
-            rusqlite::params![session_id],
-            |r| r.get(0),
-        )
-        .map_err(AppError::from)?;
-
-    if total_secs == 0 {
-        return Ok(vec![]);
-    }
-
-    let mut stmt = conn
-        .prepare(
-            "SELECT app_name,
-                    SUM(duration_secs) as total,
-                    (SELECT classification FROM activities a2
-                     WHERE a2.app_name = a.app_name AND a2.session_id = ?1
-                     ORDER BY started_at DESC LIMIT 1) as cls
-             FROM activities a
-             WHERE session_id = ?1
-             GROUP BY app_name
-             ORDER BY total DESC
-             LIMIT 10",
-        )
-        .map_err(AppError::from)?;
-
-    let rows = stmt
-        .query_map(rusqlite::params![session_id], |r| {
-            Ok((r.get::<_, String>(0)?, r.get::<_, i64>(1)?, r.get::<_, String>(2)?))
+    let apps = metrics_svc::query_top_apps(&pool, &session_id)?;
+    Ok(apps
+        .into_iter()
+        .map(|a| AppStat {
+            app_name: a.app_name,
+            duration_secs: a.duration_secs,
+            classification: a.classification,
+            percentage: a.percentage,
         })
-        .map_err(AppError::from)?;
-
-    let mut result = Vec::new();
-    for row in rows {
-        let (app_name, duration, cls) = row.map_err(AppError::from)?;
-        result.push(AppStat {
-            app_name,
-            duration_secs: duration,
-            classification: cls,
-            percentage: (duration as f64 / total_secs as f64) * 100.0,
-        });
-    }
-    Ok(result)
+        .collect())
 }
 
 #[tauri::command]

--- a/src-tauri/src/services/metrics.rs
+++ b/src-tauri/src/services/metrics.rs
@@ -1,0 +1,289 @@
+use crate::errors::AppError;
+use crate::services::db::DbPool;
+
+pub struct FocusStats {
+    pub total_secs: i64,
+    pub focus_secs: i64,
+    pub neutral_secs: i64,
+    pub distraction_secs: i64,
+}
+
+pub struct AppStat {
+    pub app_name: String,
+    pub duration_secs: i64,
+    pub classification: String,
+    pub percentage: f64,
+}
+
+/// 세션의 Focus/Neutral/Distraction 누적 시간 집계
+pub fn query_focus_stats(pool: &DbPool, session_id: &str) -> Result<FocusStats, AppError> {
+    let conn = pool.get().map_err(AppError::from)?;
+
+    let started_at: i64 = conn
+        .query_row(
+            "SELECT started_at FROM sessions WHERE id = ?1",
+            rusqlite::params![session_id],
+            |r| r.get(0),
+        )
+        .map_err(AppError::from)?;
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs() as i64;
+    let total_secs = (now - started_at).max(0);
+
+    let mut stmt = conn
+        .prepare(
+            "SELECT classification, COALESCE(SUM(duration_secs), 0)
+             FROM activities WHERE session_id = ?1
+             GROUP BY classification",
+        )
+        .map_err(AppError::from)?;
+
+    let mut focus_secs = 0i64;
+    let mut neutral_secs = 0i64;
+    let mut distraction_secs = 0i64;
+
+    let rows = stmt
+        .query_map(rusqlite::params![session_id], |r| {
+            Ok((r.get::<_, String>(0)?, r.get::<_, i64>(1)?))
+        })
+        .map_err(AppError::from)?;
+
+    for row in rows {
+        let (cls, secs) = row.map_err(AppError::from)?;
+        match cls.as_str() {
+            "Focus" => focus_secs = secs,
+            "Neutral" => neutral_secs = secs,
+            "Distraction" => distraction_secs = secs,
+            _ => {}
+        }
+    }
+
+    Ok(FocusStats { total_secs, focus_secs, neutral_secs, distraction_secs })
+}
+
+/// 세션의 앱별 누적 시간 집계 (상위 10개, 내림차순)
+pub fn query_top_apps(pool: &DbPool, session_id: &str) -> Result<Vec<AppStat>, AppError> {
+    let conn = pool.get().map_err(AppError::from)?;
+
+    let total_secs: i64 = conn
+        .query_row(
+            "SELECT COALESCE(SUM(duration_secs), 0) FROM activities WHERE session_id = ?1",
+            rusqlite::params![session_id],
+            |r| r.get(0),
+        )
+        .map_err(AppError::from)?;
+
+    if total_secs == 0 {
+        return Ok(vec![]);
+    }
+
+    let mut stmt = conn
+        .prepare(
+            "SELECT app_name,
+                    SUM(duration_secs) as total,
+                    (SELECT classification FROM activities a2
+                     WHERE a2.app_name = a.app_name AND a2.session_id = ?1
+                     ORDER BY started_at DESC LIMIT 1) as cls
+             FROM activities a
+             WHERE session_id = ?1
+             GROUP BY app_name
+             ORDER BY total DESC
+             LIMIT 10",
+        )
+        .map_err(AppError::from)?;
+
+    let rows = stmt
+        .query_map(rusqlite::params![session_id], |r| {
+            Ok((r.get::<_, String>(0)?, r.get::<_, i64>(1)?, r.get::<_, String>(2)?))
+        })
+        .map_err(AppError::from)?;
+
+    let mut result = Vec::new();
+    for row in rows {
+        let (app_name, duration, cls) = row.map_err(AppError::from)?;
+        result.push(AppStat {
+            app_name,
+            duration_secs: duration,
+            classification: cls,
+            percentage: (duration as f64 / total_secs as f64) * 100.0,
+        });
+    }
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::services::db;
+    use r2d2_sqlite::SqliteConnectionManager;
+
+    fn setup_pool() -> DbPool {
+        let manager = SqliteConnectionManager::memory();
+        let pool = r2d2::Pool::new(manager).unwrap();
+        let mut conn = pool.get().unwrap();
+        db::run_migrations(&mut *conn).unwrap();
+        drop(conn);
+        pool
+    }
+
+    fn insert_session(pool: &DbPool, session_id: &str, started_at: i64) {
+        let conn = pool.get().unwrap();
+        conn.execute(
+            "INSERT INTO sessions (id, started_at, ended_at, is_complete) VALUES (?1, ?2, NULL, 0)",
+            rusqlite::params![session_id, started_at],
+        )
+        .unwrap();
+    }
+
+    fn insert_activity(
+        pool: &DbPool,
+        session_id: &str,
+        app_name: &str,
+        classification: &str,
+        duration_secs: i64,
+        started_at: i64,
+    ) {
+        let conn = pool.get().unwrap();
+        conn.execute(
+            "INSERT INTO activities (id, session_id, app_name, url, domain, classification, started_at, duration_secs)
+             VALUES (?, ?, ?, NULL, NULL, ?, ?, ?)",
+            rusqlite::params![
+                uuid::Uuid::new_v4().to_string(),
+                session_id,
+                app_name,
+                classification,
+                started_at,
+                duration_secs,
+            ],
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn test_focus_stats_empty_session() {
+        let pool = setup_pool();
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64;
+        insert_session(&pool, "sess-1", now);
+
+        let stats = query_focus_stats(&pool, "sess-1").unwrap();
+        assert_eq!(stats.focus_secs, 0);
+        assert_eq!(stats.neutral_secs, 0);
+        assert_eq!(stats.distraction_secs, 0);
+    }
+
+    #[test]
+    fn test_focus_stats_with_activities() {
+        let pool = setup_pool();
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64;
+        insert_session(&pool, "sess-1", now - 120);
+        insert_activity(&pool, "sess-1", "Chrome", "Focus", 60, now - 120);
+        insert_activity(&pool, "sess-1", "Slack", "Neutral", 30, now - 60);
+        insert_activity(&pool, "sess-1", "YouTube", "Distraction", 30, now - 30);
+
+        let stats = query_focus_stats(&pool, "sess-1").unwrap();
+        assert_eq!(stats.focus_secs, 60);
+        assert_eq!(stats.neutral_secs, 30);
+        assert_eq!(stats.distraction_secs, 30);
+    }
+
+    #[test]
+    fn test_focus_stats_percentage_sum_is_100() {
+        let pool = setup_pool();
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64;
+        insert_session(&pool, "sess-1", now - 120);
+        insert_activity(&pool, "sess-1", "Chrome", "Focus", 60, now - 120);
+        insert_activity(&pool, "sess-1", "Slack", "Neutral", 30, now - 60);
+        insert_activity(&pool, "sess-1", "YouTube", "Distraction", 30, now - 30);
+
+        let stats = query_focus_stats(&pool, "sess-1").unwrap();
+        let recorded = stats.focus_secs + stats.neutral_secs + stats.distraction_secs;
+        assert_eq!(recorded, 120);
+        // 퍼센트 합 100% 검증
+        let total = recorded as f64;
+        let pct_sum = (stats.focus_secs as f64 / total
+            + stats.neutral_secs as f64 / total
+            + stats.distraction_secs as f64 / total)
+            * 100.0;
+        let diff = (pct_sum - 100.0).abs();
+        assert!(diff < 0.01, "퍼센트 합이 100%여야 함, 실제: {pct_sum}");
+    }
+
+    #[test]
+    fn test_top_apps_empty_returns_empty_vec() {
+        let pool = setup_pool();
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64;
+        insert_session(&pool, "sess-1", now);
+
+        let apps = query_top_apps(&pool, "sess-1").unwrap();
+        assert!(apps.is_empty());
+    }
+
+    #[test]
+    fn test_top_apps_sorted_by_duration_desc() {
+        let pool = setup_pool();
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64;
+        insert_session(&pool, "sess-1", now - 200);
+        insert_activity(&pool, "sess-1", "Slack", "Neutral", 40, now - 200);
+        insert_activity(&pool, "sess-1", "Chrome", "Focus", 100, now - 160);
+        insert_activity(&pool, "sess-1", "YouTube", "Distraction", 60, now - 60);
+
+        let apps = query_top_apps(&pool, "sess-1").unwrap();
+        assert_eq!(apps.len(), 3);
+        assert_eq!(apps[0].app_name, "Chrome");
+        assert_eq!(apps[0].duration_secs, 100);
+        assert_eq!(apps[1].app_name, "YouTube");
+        assert_eq!(apps[2].app_name, "Slack");
+    }
+
+    #[test]
+    fn test_top_apps_percentage_correct() {
+        let pool = setup_pool();
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64;
+        insert_session(&pool, "sess-1", now - 100);
+        insert_activity(&pool, "sess-1", "Chrome", "Focus", 75, now - 100);
+        insert_activity(&pool, "sess-1", "Slack", "Neutral", 25, now - 25);
+
+        let apps = query_top_apps(&pool, "sess-1").unwrap();
+        let chrome = apps.iter().find(|a| a.app_name == "Chrome").unwrap();
+        let slack = apps.iter().find(|a| a.app_name == "Slack").unwrap();
+        let diff_chrome = (chrome.percentage - 75.0).abs();
+        let diff_slack = (slack.percentage - 25.0).abs();
+        assert!(diff_chrome < 0.01, "Chrome 퍼센트: {}", chrome.percentage);
+        assert!(diff_slack < 0.01, "Slack 퍼센트: {}", slack.percentage);
+    }
+
+    #[test]
+    fn test_top_apps_classification_matches() {
+        let pool = setup_pool();
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64;
+        insert_session(&pool, "sess-1", now - 60);
+        insert_activity(&pool, "sess-1", "Chrome", "Focus", 60, now - 60);
+
+        let apps = query_top_apps(&pool, "sess-1").unwrap();
+        assert_eq!(apps[0].classification, "Focus");
+    }
+}

--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -1,5 +1,6 @@
 pub mod browser;
 pub mod classifier;
 pub mod db;
+pub mod metrics;
 pub mod session;
 pub mod tracker;

--- a/src-tauri/tests/metrics_tests.rs
+++ b/src-tauri/tests/metrics_tests.rs
@@ -1,0 +1,172 @@
+// metrics 서비스 통합 테스트 — in-memory SQLite 사용
+#[cfg(test)]
+mod tests {
+    use focaro_lib::services::db;
+    use focaro_lib::services::metrics;
+    use r2d2_sqlite::SqliteConnectionManager;
+
+    fn setup_pool() -> r2d2::Pool<SqliteConnectionManager> {
+        let manager = SqliteConnectionManager::memory();
+        let pool = r2d2::Pool::new(manager).unwrap();
+        let mut conn = pool.get().unwrap();
+        db::run_migrations(&mut *conn).unwrap();
+        drop(conn);
+        pool
+    }
+
+    fn insert_session(pool: &r2d2::Pool<SqliteConnectionManager>, id: &str, started_at: i64) {
+        let conn = pool.get().unwrap();
+        conn.execute(
+            "INSERT INTO sessions (id, started_at, ended_at, is_complete) VALUES (?1, ?2, NULL, 0)",
+            rusqlite::params![id, started_at],
+        )
+        .unwrap();
+    }
+
+    fn insert_activity(
+        pool: &r2d2::Pool<SqliteConnectionManager>,
+        session_id: &str,
+        app_name: &str,
+        classification: &str,
+        duration_secs: i64,
+        started_at: i64,
+    ) {
+        let conn = pool.get().unwrap();
+        conn.execute(
+            "INSERT INTO activities (id, session_id, app_name, url, domain, classification, started_at, duration_secs)
+             VALUES (?, ?, ?, NULL, NULL, ?, ?, ?)",
+            rusqlite::params![
+                uuid::Uuid::new_v4().to_string(),
+                session_id,
+                app_name,
+                classification,
+                started_at,
+                duration_secs,
+            ],
+        )
+        .unwrap();
+    }
+
+    // ── FocusStats 통합 테스트 ─────────────────────────────────
+
+    #[test]
+    fn test_focus_stats_multiple_classifications() {
+        let pool = setup_pool();
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64;
+
+        insert_session(&pool, "s1", now - 300);
+        insert_activity(&pool, "s1", "Chrome", "Focus", 120, now - 300);
+        insert_activity(&pool, "s1", "Slack", "Neutral", 60, now - 180);
+        insert_activity(&pool, "s1", "YouTube", "Distraction", 60, now - 120);
+        insert_activity(&pool, "s1", "VSCode", "Focus", 60, now - 60);
+
+        let stats = metrics::query_focus_stats(&pool, "s1").unwrap();
+        assert_eq!(stats.focus_secs, 180, "Focus: 120+60=180");
+        assert_eq!(stats.neutral_secs, 60);
+        assert_eq!(stats.distraction_secs, 60);
+    }
+
+    #[test]
+    fn test_focus_stats_session_isolation() {
+        let pool = setup_pool();
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64;
+
+        insert_session(&pool, "s1", now - 100);
+        insert_session(&pool, "s2", now - 100);
+        insert_activity(&pool, "s1", "Chrome", "Focus", 80, now - 100);
+        insert_activity(&pool, "s2", "YouTube", "Distraction", 90, now - 100);
+
+        let stats_s1 = metrics::query_focus_stats(&pool, "s1").unwrap();
+        let stats_s2 = metrics::query_focus_stats(&pool, "s2").unwrap();
+
+        assert_eq!(stats_s1.focus_secs, 80);
+        assert_eq!(stats_s1.distraction_secs, 0);
+        assert_eq!(stats_s2.distraction_secs, 90);
+        assert_eq!(stats_s2.focus_secs, 0);
+    }
+
+    #[test]
+    fn test_focus_stats_total_secs_is_elapsed_time() {
+        let pool = setup_pool();
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64;
+        let started_at = now - 300;
+
+        insert_session(&pool, "s1", started_at);
+        let stats = metrics::query_focus_stats(&pool, "s1").unwrap();
+        // total_secs는 now - started_at 기반, 최소 300 이상
+        assert!(stats.total_secs >= 300, "total_secs={}", stats.total_secs);
+    }
+
+    // ── TopApps 통합 테스트 ──────────────────────────────────────
+
+    #[test]
+    fn test_top_apps_limit_10() {
+        let pool = setup_pool();
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64;
+        insert_session(&pool, "s1", now - 1100);
+
+        // 11개 앱 삽입
+        for i in 0..11 {
+            insert_activity(
+                &pool,
+                "s1",
+                &format!("App{}", i),
+                "Neutral",
+                10,
+                now - 1100 + i * 10,
+            );
+        }
+
+        let apps = metrics::query_top_apps(&pool, "s1").unwrap();
+        assert!(apps.len() <= 10, "최대 10개 반환, 실제: {}", apps.len());
+    }
+
+    #[test]
+    fn test_top_apps_same_app_aggregated() {
+        let pool = setup_pool();
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64;
+        insert_session(&pool, "s1", now - 200);
+
+        // 같은 앱의 활동 2개 → 합산되어야 함
+        insert_activity(&pool, "s1", "Chrome", "Focus", 60, now - 200);
+        insert_activity(&pool, "s1", "Chrome", "Focus", 40, now - 140);
+        insert_activity(&pool, "s1", "Slack", "Neutral", 100, now - 100);
+
+        let apps = metrics::query_top_apps(&pool, "s1").unwrap();
+        let chrome = apps.iter().find(|a| a.app_name == "Chrome").unwrap();
+        assert_eq!(chrome.duration_secs, 100, "Chrome 합산: 60+40=100");
+    }
+
+    #[test]
+    fn test_top_apps_percentage_sums_to_100() {
+        let pool = setup_pool();
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64;
+        insert_session(&pool, "s1", now - 300);
+        insert_activity(&pool, "s1", "Chrome", "Focus", 150, now - 300);
+        insert_activity(&pool, "s1", "Slack", "Neutral", 90, now - 150);
+        insert_activity(&pool, "s1", "YouTube", "Distraction", 60, now - 60);
+
+        let apps = metrics::query_top_apps(&pool, "s1").unwrap();
+        let pct_sum: f64 = apps.iter().map(|a| a.percentage).sum();
+        let diff = (pct_sum - 100.0).abs();
+        assert!(diff < 0.1, "퍼센트 합: {pct_sum}");
+    }
+}

--- a/src/__tests__/components/DonutChart.test.tsx
+++ b/src/__tests__/components/DonutChart.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { DonutChart } from "../../components/Dropdown/DonutChart";
+
+describe("DonutChart", () => {
+  it("focus/neutral/distraction 데이터로 렌더링", () => {
+    const { container } = render(
+      <DonutChart focus={60} neutral={20} distraction={20} />
+    );
+    const circles = container.querySelectorAll("circle");
+    // 배경 원 + 3개 세그먼트 = 4개
+    expect(circles.length).toBe(4);
+  });
+
+  it("중앙에 focus 퍼센트 표시", () => {
+    render(<DonutChart focus={60} neutral={20} distraction={20} />);
+    // 60 / (60+20+20) = 60%
+    expect(screen.getByText("60%")).toBeTruthy();
+    expect(screen.getByText("focus")).toBeTruthy();
+  });
+
+  it("총합 0일 때 0% 표시", () => {
+    render(<DonutChart focus={0} neutral={0} distraction={0} />);
+    expect(screen.getByText("0%")).toBeTruthy();
+  });
+
+  it("총합 0일 때 배경 원만 렌더링 (세그먼트 없음)", () => {
+    const { container } = render(
+      <DonutChart focus={0} neutral={0} distraction={0} />
+    );
+    // 배경 원 + 빈 상태 원 = 2개 (세그먼트 없음)
+    const circles = container.querySelectorAll("circle");
+    expect(circles.length).toBe(2);
+  });
+
+  it("focus 100%일 때 focus 세그먼트만 렌더링", () => {
+    const { container } = render(
+      <DonutChart focus={100} neutral={0} distraction={0} />
+    );
+    expect(screen.getByText("100%")).toBeTruthy();
+    // 배경 + focus = 2개
+    const circles = container.querySelectorAll("circle");
+    expect(circles.length).toBe(2);
+  });
+
+  it("size prop으로 SVG 크기 조정 가능", () => {
+    const { container } = render(
+      <DonutChart focus={50} neutral={30} distraction={20} size={120} />
+    );
+    const svg = container.querySelector("svg");
+    expect(svg?.getAttribute("width")).toBe("120");
+    expect(svg?.getAttribute("height")).toBe("120");
+  });
+});

--- a/src/__tests__/components/Dropdown.test.tsx
+++ b/src/__tests__/components/Dropdown.test.tsx
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { mockIPC } from "@tauri-apps/api/mocks";
+import { Dropdown } from "../../pages/Dropdown";
+
+// getCurrentWindow().hide() 모킹
+vi.mock("@tauri-apps/api/window", () => ({
+  getCurrentWindow: () => ({
+    label: "dropdown",
+    hide: vi.fn().mockResolvedValue(undefined),
+  }),
+}));
+
+const SESSION_MOCK = {
+  id: "sess-1",
+  started_at: new Date(Date.now() - 60000).toISOString(),
+  ended_at: null,
+  status: "Active" as const,
+};
+
+const FOCUS_STATS_MOCK = {
+  total_secs: 60,
+  focus_secs: 36,
+  neutral_secs: 12,
+  distraction_secs: 12,
+};
+
+const TOP_APPS_MOCK = [
+  { app_name: "Google Chrome", duration_secs: 36, classification: "Focus", percentage: 60 },
+  { app_name: "Slack", duration_secs: 24, classification: "Neutral", percentage: 40 },
+];
+
+function setupIPC({
+  incomplete = null,
+  session = null,
+  focusStats = FOCUS_STATS_MOCK,
+  topApps = TOP_APPS_MOCK,
+  currentApp = "Google Chrome",
+}: {
+  incomplete?: typeof SESSION_MOCK | null;
+  session?: typeof SESSION_MOCK | null;
+  focusStats?: typeof FOCUS_STATS_MOCK;
+  topApps?: typeof TOP_APPS_MOCK;
+  currentApp?: string | null;
+} = {}) {
+  mockIPC((cmd) => {
+    switch (cmd) {
+      case "get_incomplete_session": return incomplete;
+      case "get_current_session": return session;
+      case "start_session": return SESSION_MOCK;
+      case "end_session": return null;
+      case "get_focus_stats": return focusStats;
+      case "get_top_apps": return topApps;
+      case "get_current_app": return currentApp;
+      case "open_dashboard": return undefined;
+      default: return undefined;
+    }
+  });
+}
+
+describe("Dropdown", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("세션 없을 때 '세션 시작' 버튼 표시", async () => {
+    setupIPC();
+    render(<Dropdown />);
+    await waitFor(() => {
+      expect(screen.getByText("세션 시작")).toBeTruthy();
+    });
+  });
+
+  it("미완료 세션 있을 때 복구 팝업 표시", async () => {
+    setupIPC({ incomplete: SESSION_MOCK });
+    render(<Dropdown />);
+    await waitFor(() => {
+      expect(screen.getByText("이전 세션이 종료되지 않았습니다")).toBeTruthy();
+      expect(screen.getByText("이어가기")).toBeTruthy();
+      expect(screen.getByText("종료")).toBeTruthy();
+    });
+  });
+
+  it("세션 없을 때 타이머 '--:--' 표시", async () => {
+    setupIPC();
+    render(<Dropdown />);
+    await waitFor(() => {
+      expect(screen.getByText("--:--")).toBeTruthy();
+    });
+  });
+
+  it("'세션 시작' 클릭 시 세션 시작됨", async () => {
+    setupIPC();
+    render(<Dropdown />);
+    await waitFor(() => screen.getByText("세션 시작"));
+    fireEvent.click(screen.getByText("세션 시작"));
+    await waitFor(() => {
+      expect(screen.getByText("세션 종료")).toBeTruthy();
+    });
+  });
+
+  it("세션 활성 상태에서 도넛 차트 렌더링", async () => {
+    setupIPC({ incomplete: null });
+    render(<Dropdown />);
+    // 세션 시작
+    await waitFor(() => screen.getByText("세션 시작"));
+    fireEvent.click(screen.getByText("세션 시작"));
+    await waitFor(() => {
+      const svg = document.querySelector("svg");
+      expect(svg).toBeTruthy();
+    });
+  });
+
+  it("세션 활성 상태에서 앱 리스트 표시", async () => {
+    setupIPC({ incomplete: null });
+    render(<Dropdown />);
+    await waitFor(() => screen.getByText("세션 시작"));
+    fireEvent.click(screen.getByText("세션 시작"));
+    await waitFor(() => {
+      const items = screen.getAllByText("Google Chrome");
+      expect(items.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  it("Dashboard 열기 버튼 존재", async () => {
+    setupIPC();
+    render(<Dropdown />);
+    await waitFor(() => {
+      expect(screen.getByText("Dashboard 열기")).toBeTruthy();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

TDD 원칙(헌법 III) 준수를 위해 US2/US3 구현 후 작성되지 않았던 테스트를 보완하고, 메트릭 쿼리 로직을 서비스 레이어로 분리함.

- **T028**: `DonutChart.test.tsx` — 렌더링, 빈 상태, 퍼센트 계산, size prop (6개)
- **T029**: `Dropdown.test.tsx` — mockIPC 기반 세션/복구/UI 통합 테스트 (7개)
- **T039**: `services/metrics.rs` 신규 생성 — `query_focus_stats`, `query_top_apps` 로직 분리 + 단위 테스트 (6개)
- **T040**: `tests/metrics_tests.rs` — 세션 격리, 집계, 퍼센트 합 통합 테스트 (6개)
- `commands/session.rs`: 중복 쿼리 로직 → metrics 서비스 위임 (DRY 원칙)

## Test Results

- `cargo test`: 42개 (unit) + 14개 (integration) = **56개 전체 통과**
- `npm test`: **16개 전체 통과**

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)