### PR TITLE
[#18] US6 설정 창 및 Reference 저장 팝업

### DIFF
--- a/specs/002-us6-settings-popup/spec.md
+++ b/specs/002-us6-settings-popup/spec.md
@@ -1,0 +1,115 @@
+# Feature Specification: [FEATURE NAME]
+
+**Feature Branch**: `[###-feature-name]`  
+**Created**: [DATE]  
+**Status**: Draft  
+**Input**: User description: "$ARGUMENTS"
+
+## User Scenarios & Testing *(mandatory)*
+
+<!--
+  IMPORTANT: User stories should be PRIORITIZED as user journeys ordered by importance.
+  Each user story/journey must be INDEPENDENTLY TESTABLE - meaning if you implement just ONE of them,
+  you should still have a viable MVP (Minimum Viable Product) that delivers value.
+  
+  Assign priorities (P1, P2, P3, etc.) to each story, where P1 is the most critical.
+  Think of each story as a standalone slice of functionality that can be:
+  - Developed independently
+  - Tested independently
+  - Deployed independently
+  - Demonstrated to users independently
+-->
+
+### User Story 1 - [Brief Title] (Priority: P1)
+
+[Describe this user journey in plain language]
+
+**Why this priority**: [Explain the value and why it has this priority level]
+
+**Independent Test**: [Describe how this can be tested independently - e.g., "Can be fully tested by [specific action] and delivers [specific value]"]
+
+**Acceptance Scenarios**:
+
+1. **Given** [initial state], **When** [action], **Then** [expected outcome]
+2. **Given** [initial state], **When** [action], **Then** [expected outcome]
+
+---
+
+### User Story 2 - [Brief Title] (Priority: P2)
+
+[Describe this user journey in plain language]
+
+**Why this priority**: [Explain the value and why it has this priority level]
+
+**Independent Test**: [Describe how this can be tested independently]
+
+**Acceptance Scenarios**:
+
+1. **Given** [initial state], **When** [action], **Then** [expected outcome]
+
+---
+
+### User Story 3 - [Brief Title] (Priority: P3)
+
+[Describe this user journey in plain language]
+
+**Why this priority**: [Explain the value and why it has this priority level]
+
+**Independent Test**: [Describe how this can be tested independently]
+
+**Acceptance Scenarios**:
+
+1. **Given** [initial state], **When** [action], **Then** [expected outcome]
+
+---
+
+[Add more user stories as needed, each with an assigned priority]
+
+### Edge Cases
+
+<!--
+  ACTION REQUIRED: The content in this section represents placeholders.
+  Fill them out with the right edge cases.
+-->
+
+- What happens when [boundary condition]?
+- How does system handle [error scenario]?
+
+## Requirements *(mandatory)*
+
+<!--
+  ACTION REQUIRED: The content in this section represents placeholders.
+  Fill them out with the right functional requirements.
+-->
+
+### Functional Requirements
+
+- **FR-001**: System MUST [specific capability, e.g., "allow users to create accounts"]
+- **FR-002**: System MUST [specific capability, e.g., "validate email addresses"]  
+- **FR-003**: Users MUST be able to [key interaction, e.g., "reset their password"]
+- **FR-004**: System MUST [data requirement, e.g., "persist user preferences"]
+- **FR-005**: System MUST [behavior, e.g., "log all security events"]
+
+*Example of marking unclear requirements:*
+
+- **FR-006**: System MUST authenticate users via [NEEDS CLARIFICATION: auth method not specified - email/password, SSO, OAuth?]
+- **FR-007**: System MUST retain user data for [NEEDS CLARIFICATION: retention period not specified]
+
+### Key Entities *(include if feature involves data)*
+
+- **[Entity 1]**: [What it represents, key attributes without implementation]
+- **[Entity 2]**: [What it represents, relationships to other entities]
+
+## Success Criteria *(mandatory)*
+
+<!--
+  ACTION REQUIRED: Define measurable success criteria.
+  These must be technology-agnostic and measurable.
+-->
+
+### Measurable Outcomes
+
+- **SC-001**: [Measurable metric, e.g., "Users can complete account creation in under 2 minutes"]
+- **SC-002**: [Measurable metric, e.g., "System handles 1000 concurrent users without degradation"]
+- **SC-003**: [User satisfaction metric, e.g., "90% of users successfully complete primary task on first attempt"]
+- **SC-004**: [Business metric, e.g., "Reduce support tickets related to [X] by 50%"]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1098,6 +1098,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-nspanel",
+ "tauri-plugin-global-shortcut",
  "tauri-plugin-opener",
  "tauri-specta",
  "thiserror 1.0.69",
@@ -1366,6 +1367,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1497,6 +1508,24 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "global-hotkey"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9247516746aa8e53411a0db9b62b0e24efbcf6a76e0ba73e5a91b512ddabed7"
+dependencies = [
+ "crossbeam-channel",
+ "keyboard-types",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "once_cell",
+ "serde",
+ "thiserror 2.0.18",
+ "windows-sys 0.59.0",
+ "x11rb",
+ "xkeysym",
+]
 
 [[package]]
 name = "gobject-sys"
@@ -4186,6 +4215,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-global-shortcut"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "424af23c7e88d05e4a1a6fc2c7be077912f8c76bd7900fd50aa2b7cbf5a2c405"
+dependencies = [
+ "global-hotkey",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "tauri-plugin-opener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5751,6 +5795,29 @@ dependencies = [
  "once_cell",
  "pkg-config",
 ]
+
+[[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
+name = "xkeysym"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "yoke"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -15,6 +15,7 @@ tauri-build = { version = "2", features = [] }
 [dependencies]
 tauri = { version = "2", features = ["macos-private-api", "tray-icon"] }
 tauri-plugin-opener = "2"
+tauri-plugin-global-shortcut = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -2,9 +2,11 @@
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
   "description": "focaro 앱 기본 권한",
-  "windows": ["dropdown", "dashboard"],
+  "windows": ["dropdown", "dashboard", "save-reference", "settings"],
   "permissions": [
     "core:default",
-    "opener:default"
+    "opener:default",
+    "global-shortcut:allow-register",
+    "global-shortcut:allow-unregister-all"
   ]
 }

--- a/src-tauri/migrations/V4__shortcut_setting.sql
+++ b/src-tauri/migrations/V4__shortcut_setting.sql
@@ -1,0 +1,2 @@
+-- V4: 전역 단축키 기본 설정 추가
+INSERT OR IGNORE INTO settings (key, value) VALUES ('shortcut_save_ref', 'CmdOrCtrl+Shift+R');

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,3 +1,4 @@
 pub mod activity;
 pub mod reference;
 pub mod session;
+pub mod settings;

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -1,0 +1,144 @@
+use std::sync::Mutex;
+use tauri::{Manager, State};
+
+use crate::errors::AppError;
+use crate::models::settings::{AppSettings, ClassificationRule};
+use crate::state::app_state::AppState;
+
+// ─── 커맨드 ─────────────────────────────────────────────────────────────────
+
+#[tauri::command]
+pub async fn get_settings(state: State<'_, Mutex<AppState>>) -> Result<AppSettings, AppError> {
+    let pool = state.lock().unwrap().db_pool.clone();
+    let conn = pool.get().map_err(AppError::from)?;
+    crate::services::settings::get_settings(&conn)
+}
+
+#[tauri::command]
+pub async fn update_settings(
+    state: State<'_, Mutex<AppState>>,
+    app: tauri::AppHandle,
+    settings: AppSettings,
+) -> Result<(), AppError> {
+    let pool = state.lock().unwrap().db_pool.clone();
+    let conn = pool.get().map_err(AppError::from)?;
+    crate::services::settings::update_settings(&conn, &settings)?;
+
+    // 단축키 변경 시 재등록
+    crate::register_save_reference_shortcut(&app, &settings.shortcut_save_ref);
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn get_classification_rules(
+    state: State<'_, Mutex<AppState>>,
+) -> Result<Vec<ClassificationRule>, AppError> {
+    let pool = state.lock().unwrap().db_pool.clone();
+    let conn = pool.get().map_err(AppError::from)?;
+    crate::services::settings::get_classification_rules(&conn)
+}
+
+#[tauri::command]
+pub async fn add_classification_rule(
+    state: State<'_, Mutex<AppState>>,
+    domain: String,
+    category: String,
+) -> Result<ClassificationRule, AppError> {
+    let pool = state.lock().unwrap().db_pool.clone();
+    let conn = pool.get().map_err(AppError::from)?;
+    crate::services::settings::add_classification_rule(&conn, &domain, &category)
+}
+
+#[tauri::command]
+pub async fn delete_classification_rule(
+    state: State<'_, Mutex<AppState>>,
+    id: i64,
+) -> Result<(), AppError> {
+    let pool = state.lock().unwrap().db_pool.clone();
+    let conn = pool.get().map_err(AppError::from)?;
+    crate::services::settings::delete_classification_rule(&conn, id)
+}
+
+#[tauri::command]
+pub async fn open_settings_window(app: tauri::AppHandle) -> Result<(), AppError> {
+    if let Some(win) = app.get_webview_window("settings") {
+        let _ = win.show();
+        let _ = win.set_focus();
+    }
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn open_save_reference_window(app: tauri::AppHandle) -> Result<(), AppError> {
+    if let Some(win) = app.get_webview_window("save-reference") {
+        let _ = win.show();
+        let _ = win.set_focus();
+    }
+    Ok(())
+}
+
+// ─── 테스트 ─────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use rusqlite::Connection;
+
+    use crate::services::db;
+    use crate::services::settings as svc;
+
+    fn setup() -> Connection {
+        let mut conn = Connection::open_in_memory().unwrap();
+        db::run_migrations(&mut conn).unwrap();
+        conn
+    }
+
+    #[test]
+    fn test_get_settings_returns_defaults() {
+        let conn = setup();
+        let s = svc::get_settings(&conn).unwrap();
+        assert_eq!(s.retention_days, 30);
+        assert_eq!(s.shortcut_save_ref, "CmdOrCtrl+Shift+R");
+    }
+
+    #[test]
+    fn test_update_settings_persists() {
+        let conn = setup();
+        let mut s = svc::get_settings(&conn).unwrap();
+        s.retention_days = 7;
+        s.shortcut_save_ref = "CmdOrCtrl+Shift+S".to_string();
+        svc::update_settings(&conn, &s).unwrap();
+
+        let updated = svc::get_settings(&conn).unwrap();
+        assert_eq!(updated.retention_days, 7);
+        assert_eq!(updated.shortcut_save_ref, "CmdOrCtrl+Shift+S");
+    }
+
+    #[test]
+    fn test_get_classification_rules_returns_defaults() {
+        let conn = setup();
+        let rules = svc::get_classification_rules(&conn).unwrap();
+        assert!(!rules.is_empty());
+        assert!(rules.iter().any(|r| r.domain == "github.com" && r.category == "Focus"));
+    }
+
+    #[test]
+    fn test_add_classification_rule_and_retrieve() {
+        let conn = setup();
+        let rule = svc::add_classification_rule(&conn, "example.com", "Distraction").unwrap();
+        assert_eq!(rule.domain, "example.com");
+        assert_eq!(rule.category, "Distraction");
+
+        let rules = svc::get_classification_rules(&conn).unwrap();
+        assert!(rules.iter().any(|r| r.domain == "example.com"));
+    }
+
+    #[test]
+    fn test_delete_classification_rule() {
+        let conn = setup();
+        let rule = svc::add_classification_rule(&conn, "todelete.com", "Neutral").unwrap();
+        svc::delete_classification_rule(&conn, rule.id).unwrap();
+
+        let rules = svc::get_classification_rules(&conn).unwrap();
+        assert!(!rules.iter().any(|r| r.domain == "todelete.com"));
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -16,12 +16,16 @@ use tauri_nspanel::ManagerExt;
 
 use services::db;
 use state::app_state::AppState;
+use tauri_plugin_global_shortcut::{GlobalShortcutExt, Shortcut, ShortcutState};
 
 pub fn run() {
     let mut builder = tauri::Builder::default();
 
     // opener 플러그인 — URL/파일을 기본 앱으로 열기, 크로스플랫폼 지원
     builder = builder.plugin(tauri_plugin_opener::init());
+
+    // global-shortcut 플러그인 — 전역 단축키 등록 (⌘⇧R)
+    builder = builder.plugin(tauri_plugin_global_shortcut::Builder::new().build());
 
     // NSPanel 플러그인 — 전체화면 앱 위에 표시되는 메뉴바 드롭다운 구현
     #[cfg(target_os = "macos")]
@@ -57,6 +61,30 @@ pub fn run() {
             #[cfg(target_os = "macos")]
             init_menubar_panel(app.handle(), &dropdown);
 
+            // 전역 단축키 ⌘⇧R → Reference 저장 팝업 열기
+            let shortcut_str = {
+                let state = app.state::<Mutex<AppState>>();
+                let pool = state.lock().unwrap().db_pool.clone();
+                let conn = pool.get().expect("DB 연결 실패");
+                services::settings::get_settings(&conn)
+                    .map(|s| s.shortcut_save_ref)
+                    .unwrap_or_else(|_| "CmdOrCtrl+Shift+R".to_string())
+            };
+            register_save_reference_shortcut(app.handle(), &shortcut_str);
+
+            // 설정 창 / Reference 팝업: X로 닫아도 숨기기만 함
+            for label in &["settings", "save-reference"] {
+                if let Some(win) = app.get_webview_window(label) {
+                    let w = win.clone();
+                    win.on_window_event(move |event| {
+                        if let tauri::WindowEvent::CloseRequested { api, .. } = event {
+                            api.prevent_close();
+                            let _ = w.hide();
+                        }
+                    });
+                }
+            }
+
             // 대시보드 창: X로 닫아도 파괴되지 않고 숨기기만 함
             // → 재오픈 시 get_webview_window("dashboard")가 항상 Some을 반환
             if let Some(dashboard) = app.get_webview_window("dashboard") {
@@ -70,8 +98,9 @@ pub fn run() {
             }
 
             // 트레이 우클릭 메뉴
+            let settings_item = MenuItem::with_id(app, "settings", "설정", true, None::<&str>)?;
             let quit_item = MenuItem::with_id(app, "quit", "focaro 종료", true, None::<&str>)?;
-            let tray_menu = Menu::with_items(app, &[&quit_item])?;
+            let tray_menu = Menu::with_items(app, &[&settings_item, &quit_item])?;
 
             // 트레이 클릭 핸들러
             let tray_app = app.handle().clone();
@@ -80,8 +109,15 @@ pub fn run() {
                 .menu(&tray_menu)
                 .show_menu_on_left_click(false)
                 .on_menu_event(|app, event| {
-                    if event.id() == "quit" {
-                        app.exit(0);
+                    match event.id().as_ref() {
+                        "quit" => app.exit(0),
+                        "settings" => {
+                            if let Some(win) = app.get_webview_window("settings") {
+                                let _ = win.show();
+                                let _ = win.set_focus();
+                            }
+                        }
+                        _ => {}
                     }
                 })
                 .on_tray_icon_event(move |tray, event| {
@@ -144,6 +180,13 @@ pub fn run() {
             commands::activity::get_top_sites,
             commands::activity::get_daily_focus_stats,
             commands::activity::get_session_events,
+            commands::settings::get_settings,
+            commands::settings::update_settings,
+            commands::settings::get_classification_rules,
+            commands::settings::add_classification_rule,
+            commands::settings::delete_classification_rule,
+            commands::settings::open_settings_window,
+            commands::settings::open_save_reference_window,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
@@ -251,6 +294,31 @@ fn request_accessibility_permission() {
             forKey: &*key
         ];
         AXIsProcessTrustedWithOptions(dict as *const std::ffi::c_void);
+    }
+}
+
+/// 전역 단축키 등록 (설정 변경 시 재호출)
+pub fn register_save_reference_shortcut(app: &tauri::AppHandle, shortcut_str: &str) {
+    // 기존 단축키 전체 해제 후 재등록
+    let _ = app.global_shortcut().unregister_all();
+
+    let Ok(shortcut) = shortcut_str.parse::<Shortcut>() else {
+        eprintln!("단축키 파싱 실패: {shortcut_str}");
+        return;
+    };
+
+    let app_handle = app.clone();
+    let result = app.global_shortcut().on_shortcut(shortcut, move |_app, _shortcut, event| {
+        if event.state == ShortcutState::Pressed {
+            if let Some(win) = app_handle.get_webview_window("save-reference") {
+                let _ = win.show();
+                let _ = win.set_focus();
+            }
+        }
+    });
+
+    if let Err(e) = result {
+        eprintln!("단축키 등록 실패: {e}");
     }
 }
 

--- a/src-tauri/src/models/settings.rs
+++ b/src-tauri/src/models/settings.rs
@@ -2,13 +2,24 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AppSettings {
-    pub retention_days: u32,
+    pub retention_days: i64,
+    pub shortcut_save_ref: String,
 }
 
 impl Default for AppSettings {
     fn default() -> Self {
-        Self { retention_days: 30 }
+        Self {
+            retention_days: 30,
+            shortcut_save_ref: "CmdOrCtrl+Shift+R".to_string(),
+        }
     }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ClassificationRule {
+    pub id: i64,
+    pub domain: String,
+    pub category: String,
 }
 
 #[cfg(test)]
@@ -17,15 +28,20 @@ mod tests {
 
     #[test]
     fn test_app_settings_default() {
-        let settings = AppSettings::default();
-        assert_eq!(settings.retention_days, 30);
+        let s = AppSettings::default();
+        assert_eq!(s.retention_days, 30);
+        assert_eq!(s.shortcut_save_ref, "CmdOrCtrl+Shift+R");
     }
 
     #[test]
     fn test_app_settings_serde_roundtrip() {
-        let settings = AppSettings { retention_days: 60 };
-        let json = serde_json::to_string(&settings).unwrap();
+        let s = AppSettings {
+            retention_days: 60,
+            shortcut_save_ref: "CmdOrCtrl+Shift+S".to_string(),
+        };
+        let json = serde_json::to_string(&s).unwrap();
         let decoded: AppSettings = serde_json::from_str(&json).unwrap();
         assert_eq!(decoded.retention_days, 60);
+        assert_eq!(decoded.shortcut_save_ref, "CmdOrCtrl+Shift+S");
     }
 }

--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -6,4 +6,5 @@ pub mod db;
 pub mod metrics;
 pub mod reference;
 pub mod session;
+pub mod settings;
 pub mod tracker;

--- a/src-tauri/src/services/settings.rs
+++ b/src-tauri/src/services/settings.rs
@@ -1,0 +1,94 @@
+use rusqlite::{params, Connection};
+
+use crate::errors::AppError;
+use crate::models::settings::{AppSettings, ClassificationRule};
+
+pub fn get_settings(conn: &Connection) -> Result<AppSettings, AppError> {
+    let retention_days: i64 = conn
+        .query_row(
+            "SELECT value FROM settings WHERE key = 'retention_days'",
+            [],
+            |r| r.get::<_, String>(0),
+        )
+        .map(|v| v.parse().unwrap_or(30))
+        .unwrap_or(30);
+
+    let shortcut_save_ref: String = conn
+        .query_row(
+            "SELECT value FROM settings WHERE key = 'shortcut_save_ref'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap_or_else(|_| "CmdOrCtrl+Shift+R".to_string());
+
+    Ok(AppSettings {
+        retention_days,
+        shortcut_save_ref,
+    })
+}
+
+pub fn update_settings(conn: &Connection, settings: &AppSettings) -> Result<(), AppError> {
+    conn.execute(
+        "INSERT OR REPLACE INTO settings (key, value) VALUES ('retention_days', ?1)",
+        params![settings.retention_days.to_string()],
+    )
+    .map_err(AppError::from)?;
+
+    conn.execute(
+        "INSERT OR REPLACE INTO settings (key, value) VALUES ('shortcut_save_ref', ?1)",
+        params![settings.shortcut_save_ref],
+    )
+    .map_err(AppError::from)?;
+
+    Ok(())
+}
+
+pub fn get_classification_rules(conn: &Connection) -> Result<Vec<ClassificationRule>, AppError> {
+    let mut stmt = conn
+        .prepare("SELECT id, domain, category FROM classification_rules ORDER BY id")
+        .map_err(AppError::from)?;
+
+    let rules = stmt
+        .query_map([], |r| {
+            Ok(ClassificationRule {
+                id: r.get(0)?,
+                domain: r.get(1)?,
+                category: r.get(2)?,
+            })
+        })
+        .map_err(AppError::from)?
+        .filter_map(|r| r.ok())
+        .collect();
+
+    Ok(rules)
+}
+
+pub fn add_classification_rule(
+    conn: &Connection,
+    domain: &str,
+    category: &str,
+) -> Result<ClassificationRule, AppError> {
+    conn.execute(
+        "INSERT INTO classification_rules (domain, category) VALUES (?1, ?2)",
+        params![domain, category],
+    )
+    .map_err(AppError::from)?;
+
+    let id = conn.last_insert_rowid();
+    Ok(ClassificationRule {
+        id,
+        domain: domain.to_string(),
+        category: category.to_string(),
+    })
+}
+
+pub fn delete_classification_rule(conn: &Connection, id: i64) -> Result<(), AppError> {
+    let affected = conn
+        .execute("DELETE FROM classification_rules WHERE id = ?1", params![id])
+        .map_err(AppError::from)?;
+
+    if affected == 0 {
+        return Err(AppError::NotFound(format!("규칙 id={id} 없음")));
+    }
+    Ok(())
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -31,6 +31,24 @@
         "height": 650,
         "visible": false,
         "resizable": true
+      },
+      {
+        "label": "save-reference",
+        "title": "Reference 저장",
+        "width": 480,
+        "height": 280,
+        "visible": false,
+        "resizable": false,
+        "decorations": true
+      },
+      {
+        "label": "settings",
+        "title": "focaro 설정",
+        "width": 600,
+        "height": 500,
+        "visible": false,
+        "resizable": false,
+        "decorations": true
       }
     ],
     "security": {

--- a/src-tauri/tests/activity_tests.rs
+++ b/src-tauri/tests/activity_tests.rs
@@ -94,8 +94,9 @@ mod tests {
 
         let rows = activity::query_activity_timeline(&pool, &date).unwrap();
         assert_eq!(rows.len(), 2, "날짜에 맞는 활동 2개");
-        assert_eq!(rows[0].app_name, "Chrome");
-        assert_eq!(rows[1].app_name, "Slack");
+        // DESC 정렬: 최신 활동이 먼저
+        assert_eq!(rows[0].app_name, "Slack");
+        assert_eq!(rows[1].app_name, "Chrome");
     }
 
     #[test]
@@ -109,8 +110,9 @@ mod tests {
         insert_activity_with_domain(&pool, "s1", "Chrome", Some("github.com"), "Focus", 60, ts);
 
         let rows = activity::query_activity_timeline(&pool, &date).unwrap();
-        assert_eq!(rows[0].app_name, "Chrome", "시간순 정렬: Chrome이 먼저");
-        assert_eq!(rows[1].app_name, "Slack");
+        // DESC 정렬: 최신(Slack, ts+120)이 먼저
+        assert_eq!(rows[0].app_name, "Slack", "DESC 정렬: Slack이 먼저");
+        assert_eq!(rows[1].app_name, "Chrome");
     }
 
     #[test]

--- a/src/App.css
+++ b/src/App.css
@@ -807,3 +807,282 @@ body {
   margin-top: 6px;
   text-align: right;
 }
+
+/* ── Settings 페이지 ─────────────────────────────────────────────────────── */
+
+.settings-page {
+  padding: 24px;
+  color: #e5e5ea;
+  background: #1c1c1e;
+  min-height: 100vh;
+  font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif;
+}
+
+.settings-title {
+  font-size: 18px;
+  font-weight: 600;
+  margin-bottom: 24px;
+  color: #fff;
+}
+
+.settings-section {
+  margin-bottom: 28px;
+  border-bottom: 1px solid rgba(255,255,255,0.06);
+  padding-bottom: 20px;
+}
+
+.settings-section:last-of-type {
+  border-bottom: none;
+}
+
+.settings-section-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: #aeaeb2;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-bottom: 8px;
+}
+
+.settings-desc {
+  font-size: 12px;
+  color: #636366;
+  margin-bottom: 12px;
+}
+
+.settings-shortcut-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.settings-shortcut-badge {
+  background: rgba(255,255,255,0.08);
+  border-radius: 6px;
+  padding: 5px 12px;
+  font-size: 13px;
+  font-family: "SF Mono", "Fira Code", monospace;
+  color: #e5e5ea;
+}
+
+.settings-shortcut-input {
+  background: rgba(255,255,255,0.08);
+  border: 1px solid rgba(255,255,255,0.15);
+  border-radius: 6px;
+  padding: 5px 12px;
+  font-size: 13px;
+  color: #e5e5ea;
+  outline: none;
+  min-width: 200px;
+}
+
+.settings-radio-group {
+  display: flex;
+  gap: 20px;
+  flex-wrap: wrap;
+}
+
+.settings-radio-label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.settings-rules-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 12px;
+  max-height: 180px;
+  overflow-y: auto;
+}
+
+.settings-rule-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px;
+  background: rgba(255,255,255,0.04);
+  border-radius: 6px;
+}
+
+.settings-rule-domain {
+  flex: 1;
+  font-size: 13px;
+}
+
+.settings-rule-badge {
+  font-size: 11px;
+  padding: 2px 8px;
+  border-radius: 4px;
+  font-weight: 500;
+}
+
+.settings-rule-badge--focus { background: rgba(48,209,88,0.15); color: #30d158; }
+.settings-rule-badge--distraction { background: rgba(255,69,58,0.15); color: #ff453a; }
+.settings-rule-badge--neutral { background: rgba(255,255,255,0.08); color: #aeaeb2; }
+
+.settings-rule-add {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.settings-input {
+  flex: 1;
+  background: rgba(255,255,255,0.08);
+  border: 1px solid rgba(255,255,255,0.12);
+  border-radius: 6px;
+  padding: 6px 10px;
+  font-size: 13px;
+  color: #e5e5ea;
+  outline: none;
+}
+
+.settings-input:focus {
+  border-color: #0a84ff;
+}
+
+.settings-select {
+  background: rgba(255,255,255,0.08);
+  border: 1px solid rgba(255,255,255,0.12);
+  border-radius: 6px;
+  padding: 6px 8px;
+  font-size: 13px;
+  color: #e5e5ea;
+  outline: none;
+  cursor: pointer;
+}
+
+.settings-btn-sm {
+  background: rgba(255,255,255,0.1);
+  border: none;
+  border-radius: 6px;
+  padding: 5px 12px;
+  font-size: 12px;
+  color: #e5e5ea;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.settings-btn-sm:hover { background: rgba(255,255,255,0.15); }
+
+.settings-btn-sm--danger {
+  background: rgba(255,69,58,0.12);
+  color: #ff453a;
+}
+.settings-btn-sm--danger:hover { background: rgba(255,69,58,0.2); }
+
+.settings-footer {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 12px;
+}
+
+.settings-save-btn {
+  background: #0a84ff;
+  border: none;
+  border-radius: 8px;
+  padding: 8px 24px;
+  font-size: 14px;
+  font-weight: 600;
+  color: #fff;
+  cursor: pointer;
+}
+
+.settings-save-btn:hover { background: #0076ea; }
+.settings-save-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+
+.settings-loading {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  color: #636366;
+  font-size: 13px;
+}
+
+/* ── SaveReferencePage (팝업 창) ─────────────────────────────────────────── */
+
+.save-ref-page {
+  padding: 20px;
+  background: #1c1c1e;
+  color: #e5e5ea;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif;
+}
+
+.save-ref-page-title {
+  font-size: 16px;
+  font-weight: 600;
+  color: #fff;
+  margin: 0;
+}
+
+.save-ref-page-url {
+  font-size: 11px;
+  color: #636366;
+  margin: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.save-ref-page-input {
+  background: rgba(255,255,255,0.08);
+  border: 1px solid rgba(255,255,255,0.12);
+  border-radius: 8px;
+  padding: 9px 12px;
+  font-size: 14px;
+  color: #e5e5ea;
+  outline: none;
+}
+
+.save-ref-page-input:focus {
+  border-color: #0a84ff;
+}
+
+.save-ref-page-actions {
+  display: flex;
+  gap: 8px;
+  margin-top: auto;
+}
+
+.save-ref-page-btn {
+  flex: 1;
+  background: rgba(255,255,255,0.1);
+  border: none;
+  border-radius: 8px;
+  padding: 10px 0;
+  font-size: 14px;
+  color: #e5e5ea;
+  cursor: pointer;
+}
+
+.save-ref-page-btn--primary {
+  background: #0a84ff;
+  color: #fff;
+  font-weight: 600;
+}
+
+.save-ref-page-btn--primary:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+/* ── Dropdown footer ──────────────────────────────────────────────────────── */
+
+.dd-footer {
+  display: flex;
+  gap: 6px;
+  padding: 0 12px 12px;
+}
+
+.dd-footer .dashboard-btn {
+  flex: 1;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,16 @@
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { Dropdown } from "./pages/Dropdown";
 import { Dashboard } from "./pages/Dashboard";
+import { Settings } from "./pages/Settings";
+import { SaveReferencePage } from "./pages/SaveReferencePage";
 import "./App.css";
 
 const windowLabel = getCurrentWindow().label;
 
 function App() {
   if (windowLabel === "dashboard") return <Dashboard />;
+  if (windowLabel === "settings") return <Settings />;
+  if (windowLabel === "save-reference") return <SaveReferencePage />;
   return <Dropdown />;
 }
 

--- a/src/__tests__/pages/SaveReferencePage.test.tsx
+++ b/src/__tests__/pages/SaveReferencePage.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { mockIPC } from "@tauri-apps/api/mocks";
+import { SaveReferencePage } from "../../pages/SaveReferencePage";
+
+const REFERENCE_MOCK = {
+  id: "ref-1",
+  session_id: "sess-1",
+  url: "https://github.com",
+  title: "GitHub",
+  tags: [],
+  created_at: "2026-03-21T00:00:00Z",
+};
+
+vi.mock("@tauri-apps/api/window", () => ({
+  getCurrentWindow: () => ({ close: vi.fn() }),
+}));
+
+describe("SaveReferencePage (팝업 창 전용)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("폼이 렌더링됨", () => {
+    mockIPC((cmd) => {
+      if (cmd === "get_current_url") return "https://github.com";
+      if (cmd === "get_current_title") return "GitHub";
+    });
+    render(<SaveReferencePage />);
+    expect(screen.getByPlaceholderText(/제목/i)).toBeTruthy();
+    expect(screen.getByPlaceholderText(/태그/i)).toBeTruthy();
+  });
+
+  it("제목 없이 저장 불가", () => {
+    mockIPC((cmd) => {
+      if (cmd === "get_current_url") return "https://github.com";
+      if (cmd === "get_current_title") return null;
+    });
+    render(<SaveReferencePage />);
+    const saveBtn = screen.getByRole("button", { name: /저장/i });
+    expect((saveBtn as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("제목 입력 후 저장 버튼 활성화", async () => {
+    mockIPC((cmd) => {
+      if (cmd === "get_current_url") return "https://github.com";
+      if (cmd === "get_current_title") return null;
+    });
+    render(<SaveReferencePage />);
+    // loading 완료 대기
+    await waitFor(() => {
+      expect((screen.getByPlaceholderText(/제목/i) as HTMLInputElement).disabled).toBe(false);
+    });
+    const titleInput = screen.getByPlaceholderText(/제목/i);
+    fireEvent.change(titleInput, { target: { value: "My Ref" } });
+    const saveBtn = screen.getByRole("button", { name: /저장/i });
+    expect((saveBtn as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it("저장 성공 후 save_reference 커맨드 호출", async () => {
+    let called = false;
+    mockIPC((cmd) => {
+      if (cmd === "get_current_url") return "https://github.com";
+      if (cmd === "get_current_title") return "GitHub";
+      if (cmd === "save_reference") {
+        called = true;
+        return REFERENCE_MOCK;
+      }
+    });
+    render(<SaveReferencePage />);
+    await waitFor(() => {
+      const titleInput = screen.getByPlaceholderText(/제목/i);
+      expect((titleInput as HTMLInputElement).value).toBeTruthy();
+    });
+
+    const saveBtn = screen.getByRole("button", { name: /저장/i });
+    fireEvent.click(saveBtn);
+
+    await waitFor(() => {
+      expect(called).toBe(true);
+    });
+  });
+});

--- a/src/__tests__/pages/Settings.test.tsx
+++ b/src/__tests__/pages/Settings.test.tsx
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { mockIPC } from "@tauri-apps/api/mocks";
+import { Settings } from "../../pages/Settings";
+
+const SETTINGS_MOCK = {
+  retention_days: 30,
+  shortcut_save_ref: "CmdOrCtrl+Shift+R",
+};
+
+const RULES_MOCK = [
+  { id: 1, domain: "github.com", category: "Focus" },
+  { id: 2, domain: "youtube.com", category: "Distraction" },
+];
+
+describe("Settings 페이지", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIPC((cmd) => {
+      if (cmd === "get_settings") return SETTINGS_MOCK;
+      if (cmd === "get_classification_rules") return RULES_MOCK;
+      if (cmd === "update_settings") return null;
+      if (cmd === "add_classification_rule") return { id: 99, domain: "example.com", category: "Focus" };
+      if (cmd === "delete_classification_rule") return null;
+    });
+  });
+
+  it("설정 페이지가 렌더링됨", async () => {
+    render(<Settings />);
+    await waitFor(() => {
+      expect(screen.getByText(/보관 기간/i)).toBeTruthy();
+    });
+  });
+
+  it("현재 단축키가 표시됨", async () => {
+    render(<Settings />);
+    await waitFor(() => {
+      expect(screen.getByText("CmdOrCtrl+Shift+R")).toBeTruthy();
+    });
+  });
+
+  it("분류 규칙 목록이 표시됨", async () => {
+    render(<Settings />);
+    await waitFor(() => {
+      expect(screen.getByText("github.com")).toBeTruthy();
+      expect(screen.getByText("youtube.com")).toBeTruthy();
+    });
+  });
+
+  it("보관 기간 변경 후 저장 가능", async () => {
+    let savedSettings: unknown = null;
+    mockIPC((cmd, args) => {
+      if (cmd === "get_settings") return SETTINGS_MOCK;
+      if (cmd === "get_classification_rules") return RULES_MOCK;
+      if (cmd === "update_settings") {
+        savedSettings = (args as { settings: unknown }).settings;
+        return null;
+      }
+    });
+    render(<Settings />);
+    await waitFor(() => screen.getByText(/보관 기간/i));
+
+    const select7 = screen.getByRole("radio", { name: "7일" });
+    fireEvent.click(select7);
+
+    const saveBtn = screen.getByRole("button", { name: /저장/i });
+    fireEvent.click(saveBtn);
+
+    await waitFor(() => {
+      expect(savedSettings).toBeTruthy();
+      expect((savedSettings as { retention_days: number }).retention_days).toBe(7);
+    });
+  });
+
+  it("분류 규칙 삭제 버튼 존재", async () => {
+    render(<Settings />);
+    await waitFor(() => screen.getByText("github.com"));
+    const deleteBtns = screen.getAllByRole("button", { name: /삭제/i });
+    expect(deleteBtns.length).toBeGreaterThan(0);
+  });
+
+  it("새 분류 규칙 추가 폼 존재", async () => {
+    render(<Settings />);
+    await waitFor(() => screen.getByPlaceholderText(/도메인/i));
+    expect(screen.getByPlaceholderText(/도메인/i)).toBeTruthy();
+  });
+});

--- a/src/pages/Dropdown.tsx
+++ b/src/pages/Dropdown.tsx
@@ -13,7 +13,7 @@ import {
   getCurrentUrl,
 } from "../services/session";
 import { DonutChart } from "../components/Dropdown/DonutChart";
-import { SaveReference } from "../components/Dropdown/SaveReference";
+import { openSaveReferenceWindow, openSettingsWindow } from "../services/settings";
 
 function formatTimer(totalSecs: number): string {
   const h = Math.floor(totalSecs / 3600);
@@ -162,11 +162,20 @@ export function Dropdown() {
 
       {/* Reference 저장 (세션 진행 중일 때만) */}
       {session && (
-        <SaveReference currentUrl={currentUrl} />
+        <button
+          className={`dashboard-btn${currentUrl ? " dashboard-btn--active" : ""}`}
+          onClick={openSaveReferenceWindow}
+          disabled={!currentUrl}
+        >
+          Reference 저장
+        </button>
       )}
 
       {/* Footer */}
-      <button onClick={openDashboard} className="dashboard-btn">Dashboard 열기</button>
+      <div className="dd-footer">
+        <button onClick={openDashboard} className="dashboard-btn">Dashboard 열기</button>
+        <button onClick={openSettingsWindow} className="dashboard-btn">설정</button>
+      </div>
     </div>
   );
 }

--- a/src/pages/SaveReferencePage.tsx
+++ b/src/pages/SaveReferencePage.tsx
@@ -1,0 +1,92 @@
+import { useState, useEffect } from "react";
+import { getCurrentWindow } from "@tauri-apps/api/window";
+import { saveReference } from "../services/reference";
+import { getCurrentUrl, getCurrentTitle } from "../services/session";
+
+export function SaveReferencePage() {
+  const [url, setUrl] = useState<string>("");
+  const [title, setTitle] = useState("");
+  const [tags, setTags] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const [currentUrl, currentTitle] = await Promise.all([
+          getCurrentUrl(),
+          getCurrentTitle(),
+        ]);
+        if (currentUrl) setUrl(currentUrl);
+        if (currentTitle) setTitle(currentTitle);
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, []);
+
+  const handleSave = async () => {
+    if (!title.trim() || !url) return;
+    setSaving(true);
+    try {
+      const tagList = tags.trim()
+        ? tags.split(",").map((t) => t.trim()).filter(Boolean)
+        : [];
+      await saveReference({
+        url,
+        title: title.trim(),
+        tags: tagList.length > 0 ? tagList : null,
+      });
+      getCurrentWindow().close();
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleCancel = () => {
+    getCurrentWindow().close();
+  };
+
+  return (
+    <div className="save-ref-page">
+      <h2 className="save-ref-page-title">Reference 저장</h2>
+
+      {url && (
+        <p className="save-ref-page-url">{url}</p>
+      )}
+
+      <input
+        className="save-ref-page-input"
+        placeholder="제목 입력"
+        value={loading ? "" : title}
+        onChange={(e) => setTitle(e.target.value)}
+        autoFocus={!loading}
+        disabled={loading}
+      />
+
+      <input
+        className="save-ref-page-input"
+        placeholder="태그 (쉼표로 구분, 선택)"
+        value={tags}
+        onChange={(e) => setTags(e.target.value)}
+        disabled={loading}
+      />
+
+      <div className="save-ref-page-actions">
+        <button
+          className="save-ref-page-btn save-ref-page-btn--primary"
+          onClick={handleSave}
+          disabled={saving || !title.trim() || loading}
+        >
+          {saving ? "저장 중..." : "저장"}
+        </button>
+        <button
+          className="save-ref-page-btn"
+          onClick={handleCancel}
+        >
+          취소
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,0 +1,205 @@
+import { useState, useEffect, useCallback } from "react";
+import type { AppSettings, ClassificationRule } from "../types/bindings";
+import {
+  getSettings,
+  updateSettings,
+  getClassificationRules,
+  addClassificationRule,
+  deleteClassificationRule,
+} from "../services/settings";
+
+const RETENTION_OPTIONS = [
+  { label: "7일", value: 7 },
+  { label: "30일", value: 30 },
+  { label: "90일", value: 90 },
+  { label: "무제한", value: 0 },
+];
+
+const CATEGORY_OPTIONS = ["Focus", "Neutral", "Distraction"] as const;
+
+export function Settings() {
+  const [settings, setSettings] = useState<AppSettings | null>(null);
+  const [rules, setRules] = useState<ClassificationRule[]>([]);
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [newDomain, setNewDomain] = useState("");
+  const [newCategory, setNewCategory] = useState<string>("Focus");
+  const [addingRule, setAddingRule] = useState(false);
+  const [shortcutEditing, setShortcutEditing] = useState(false);
+  const [shortcutInput, setShortcutInput] = useState("");
+
+  const loadData = useCallback(async () => {
+    const [s, r] = await Promise.all([getSettings(), getClassificationRules()]);
+    setSettings(s);
+    setRules(r);
+  }, []);
+
+  useEffect(() => {
+    loadData();
+  }, [loadData]);
+
+  const handleSave = async () => {
+    if (!settings) return;
+    setSaving(true);
+    try {
+      await updateSettings(settings);
+      setSaved(true);
+      setTimeout(() => setSaved(false), 2000);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleShortcutCapture = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    e.preventDefault();
+    const parts: string[] = [];
+    if (e.metaKey) parts.push("CmdOrCtrl");
+    if (e.ctrlKey && !e.metaKey) parts.push("CmdOrCtrl");
+    if (e.altKey) parts.push("Alt");
+    if (e.shiftKey) parts.push("Shift");
+    const key = e.key.toUpperCase();
+    if (key.length === 1 || ["F1","F2","F3","F4","F5","F6","F7","F8","F9","F10","F11","F12"].includes(key)) {
+      parts.push(key);
+      const combo = parts.join("+");
+      setShortcutInput(combo);
+      setSettings((s) => s ? { ...s, shortcut_save_ref: combo } : s);
+      setShortcutEditing(false);
+    }
+  };
+
+  const handleAddRule = async () => {
+    if (!newDomain.trim()) return;
+    setAddingRule(true);
+    try {
+      const rule = await addClassificationRule(newDomain.trim(), newCategory);
+      setRules((r) => [...r, rule]);
+      setNewDomain("");
+    } finally {
+      setAddingRule(false);
+    }
+  };
+
+  const handleDeleteRule = async (id: number) => {
+    await deleteClassificationRule(id);
+    setRules((r) => r.filter((rule) => rule.id !== id));
+  };
+
+  if (!settings) return <div className="settings-loading">로딩 중...</div>;
+
+  return (
+    <div className="settings-page">
+      <h2 className="settings-title">focaro 설정</h2>
+
+      {/* 단축키 설정 */}
+      <section className="settings-section">
+        <h3 className="settings-section-title">전역 단축키</h3>
+        <p className="settings-desc">Reference 저장 팝업을 여는 단축키입니다.</p>
+        <div className="settings-shortcut-row">
+          {shortcutEditing ? (
+            <input
+              className="settings-shortcut-input"
+              placeholder="키를 누르세요..."
+              value={shortcutInput}
+              onKeyDown={handleShortcutCapture}
+              onChange={() => {}}
+              autoFocus
+            />
+          ) : (
+            <span className="settings-shortcut-badge">
+              {settings.shortcut_save_ref}
+            </span>
+          )}
+          <button
+            className="settings-btn-sm"
+            onClick={() => {
+              setShortcutInput(settings.shortcut_save_ref);
+              setShortcutEditing((v) => !v);
+            }}
+          >
+            {shortcutEditing ? "취소" : "변경"}
+          </button>
+        </div>
+      </section>
+
+      {/* 보관 기간 */}
+      <section className="settings-section">
+        <h3 className="settings-section-title">보관 기간</h3>
+        <p className="settings-desc">이보다 오래된 활동 데이터는 자동으로 삭제됩니다.</p>
+        <div className="settings-radio-group">
+          {RETENTION_OPTIONS.map(({ label, value }) => (
+            <label key={value} className="settings-radio-label" aria-label={label}>
+              <input
+                type="radio"
+                name="retention"
+                value={value}
+                checked={settings.retention_days === value}
+                onChange={() => setSettings((s) => s ? { ...s, retention_days: value } : s)}
+              />
+              {label}
+            </label>
+          ))}
+        </div>
+      </section>
+
+      {/* 분류 규칙 */}
+      <section className="settings-section">
+        <h3 className="settings-section-title">분류 규칙</h3>
+        <p className="settings-desc">도메인에 따라 Focus / Neutral / Distraction을 지정합니다.</p>
+
+        <div className="settings-rules-list">
+          {rules.map((rule) => (
+            <div key={rule.id} className="settings-rule-row">
+              <span className="settings-rule-domain">{rule.domain}</span>
+              <span className={`settings-rule-badge settings-rule-badge--${rule.category.toLowerCase()}`}>
+                {rule.category}
+              </span>
+              <button
+                className="settings-btn-sm settings-btn-sm--danger"
+                onClick={() => handleDeleteRule(rule.id)}
+              >
+                삭제
+              </button>
+            </div>
+          ))}
+        </div>
+
+        <div className="settings-rule-add">
+          <input
+            className="settings-input"
+            placeholder="도메인 입력 (예: example.com)"
+            value={newDomain}
+            onChange={(e) => setNewDomain(e.target.value)}
+            onKeyDown={(e) => e.key === "Enter" && handleAddRule()}
+          />
+          <select
+            className="settings-select"
+            value={newCategory}
+            onChange={(e) => setNewCategory(e.target.value)}
+          >
+            {CATEGORY_OPTIONS.map((c) => (
+              <option key={c} value={c}>{c}</option>
+            ))}
+          </select>
+          <button
+            className="settings-btn-sm"
+            onClick={handleAddRule}
+            disabled={addingRule || !newDomain.trim()}
+          >
+            추가
+          </button>
+        </div>
+      </section>
+
+      {/* 저장 버튼 */}
+      <div className="settings-footer">
+        <button
+          className="settings-save-btn"
+          onClick={handleSave}
+          disabled={saving}
+        >
+          {saved ? "저장됨 ✓" : saving ? "저장 중..." : "저장"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/services/session.ts
+++ b/src/services/session.ts
@@ -44,3 +44,7 @@ export async function getCurrentApp(): Promise<string | null> {
 export async function getCurrentUrl(): Promise<string | null> {
   return invoke<string | null>("get_current_url");
 }
+
+export async function getCurrentTitle(): Promise<string | null> {
+  return invoke<string | null>("get_current_title");
+}

--- a/src/services/settings.ts
+++ b/src/services/settings.ts
@@ -1,0 +1,43 @@
+import { invoke } from "@tauri-apps/api/core";
+
+export interface AppSettings {
+  retention_days: number;
+  shortcut_save_ref: string;
+}
+
+export interface ClassificationRule {
+  id: number;
+  domain: string;
+  category: string;
+}
+
+export async function getSettings(): Promise<AppSettings> {
+  return invoke<AppSettings>("get_settings");
+}
+
+export async function updateSettings(settings: AppSettings): Promise<void> {
+  return invoke("update_settings", { settings });
+}
+
+export async function getClassificationRules(): Promise<ClassificationRule[]> {
+  return invoke<ClassificationRule[]>("get_classification_rules");
+}
+
+export async function addClassificationRule(
+  domain: string,
+  category: string
+): Promise<ClassificationRule> {
+  return invoke<ClassificationRule>("add_classification_rule", { domain, category });
+}
+
+export async function deleteClassificationRule(id: number): Promise<void> {
+  return invoke("delete_classification_rule", { id });
+}
+
+export async function openSettingsWindow(): Promise<void> {
+  return invoke("open_settings_window");
+}
+
+export async function openSaveReferenceWindow(): Promise<void> {
+  return invoke("open_save_reference_window");
+}

--- a/src/types/bindings.ts
+++ b/src/types/bindings.ts
@@ -77,4 +77,11 @@ export interface UpdateReferenceInput {
 
 export interface AppSettings {
   retention_days: number;
+  shortcut_save_ref: string;
+}
+
+export interface ClassificationRule {
+  id: number;
+  domain: string;
+  category: string;
 }


### PR DESCRIPTION
## 개요

Phase 8 (US6) 구현: 설정 창과 전역 단축키 기반 Reference 저장 팝업.

## 변경 사항

### Rust (백엔드)
- **V4 마이그레이션**: `shortcut_save_ref` 기본 설정값 추가
- **settings 서비스/커맨드**: `get_settings`, `update_settings`, `get/add/delete_classification_rules`
- **전역 단축키**: `tauri-plugin-global-shortcut`로 `⌘⇧R` 등록 (설정 변경 시 재등록)
- **새 창**: `save-reference`, `settings` 창 추가 (X 닫기 → 숨기기)
- **트레이 메뉴**: 우클릭 메뉴에 "설정" 항목 추가

### TypeScript/React (프론트엔드)
- **SaveReferencePage**: URL/타이틀 자동 채움, 팝업 창 전용 페이지
- **Settings 페이지**: 단축키 캡처, 보관 기간 라디오, 분류 규칙 CRUD
- **Dropdown 업데이트**: 인라인 폼 → 팝업 창 호출, 설정 버튼 추가
- **settings 서비스**: `getSettings`, `updateSettings`, `openSettingsWindow` 등

## 테스트
- Rust: 54개 통과
- React: 45개 통과 (Settings 페이지 6개, SaveReferencePage 4개 신규)

Closes #18