### PR TITLE
[#20] Phase 9+10 아카이빙, 권한 처리, 최종 검증

### DIFF
--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -306,6 +306,22 @@ pub async fn get_current_title() -> Result<Option<String>, AppError> {
     Ok(None)
 }
 
+/// Accessibility 권한 여부 확인 (macOS 전용)
+/// 권한 없으면 프론트엔드에서 안내 배너 표시
+#[tauri::command]
+pub async fn check_accessibility_permission() -> bool {
+    #[cfg(target_os = "macos")]
+    {
+        #[link(name = "ApplicationServices", kind = "framework")]
+        extern "C" {
+            fn AXIsProcessTrusted() -> bool;
+        }
+        unsafe { AXIsProcessTrusted() }
+    }
+    #[cfg(not(target_os = "macos"))]
+    true
+}
+
 #[tauri::command]
 pub async fn open_dashboard(app_handle: AppHandle) -> Result<(), AppError> {
     use tauri::Manager;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -48,6 +48,24 @@ pub fn run() {
             let app_state = AppState::new(pool);
             app.manage(Mutex::new(app_state));
 
+            // 앱 시작 시 보관 기간 초과 데이터 아카이빙
+            {
+                let state = app.state::<Mutex<AppState>>();
+                let pool = state.lock().unwrap().db_pool.clone();
+                let retention_days = {
+                    let conn = pool.get().expect("DB 연결 실패");
+                    services::settings::get_settings(&conn)
+                        .map(|s| s.retention_days)
+                        .unwrap_or(30)
+                };
+                // retention_days=0은 무제한 (아카이빙 없음)
+                if retention_days > 0 {
+                    if let Err(e) = services::archive::archive_old_data(&pool, retention_days) {
+                        eprintln!("아카이빙 실패 (무시하고 계속): {e}");
+                    }
+                }
+            }
+
             // 메뉴바 전용 앱: 독 아이콘 숨김, 앱 활성화 없이 창 표시 가능
             #[cfg(target_os = "macos")]
             app.set_activation_policy(tauri::ActivationPolicy::Accessory);
@@ -172,6 +190,7 @@ pub fn run() {
             commands::session::get_current_app,
             commands::session::get_current_url,
             commands::session::get_current_title,
+            commands::session::check_accessibility_permission,
             commands::reference::save_reference,
             commands::reference::get_references,
             commands::reference::delete_reference,

--- a/src-tauri/src/services/browser.rs
+++ b/src-tauri/src/services/browser.rs
@@ -27,6 +27,11 @@ pub fn get_browser_url(app_name: &str) -> Option<String> {
             Some(url)
         }
     } else {
+        // Automation 권한 거부 또는 브라우저 창 없음 → url=null로 처리
+        if !output.stderr.is_empty() {
+            let err = String::from_utf8_lossy(&output.stderr);
+            eprintln!("[browser] URL 조회 실패 (url=null): {}", err.trim());
+        }
         None
     }
 }

--- a/src/App.css
+++ b/src/App.css
@@ -1086,3 +1086,17 @@ body {
 .dd-footer .dashboard-btn {
   flex: 1;
 }
+
+/* ── 권한 안내 배너 ────────────────────────────────────────────────────────── */
+
+.dd-permission-banner {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 14px;
+  background: rgba(255, 159, 10, 0.15);
+  border-bottom: 1px solid rgba(255, 159, 10, 0.2);
+  font-size: 11px;
+  color: #ff9f0a;
+  line-height: 1.4;
+}

--- a/src/pages/Dropdown.tsx
+++ b/src/pages/Dropdown.tsx
@@ -11,6 +11,7 @@ import {
   getTopApps,
   getCurrentApp,
   getCurrentUrl,
+  checkAccessibilityPermission,
 } from "../services/session";
 import { DonutChart } from "../components/Dropdown/DonutChart";
 import { openSaveReferenceWindow, openSettingsWindow } from "../services/settings";
@@ -38,12 +39,14 @@ export function Dropdown() {
   const [currentApp, setCurrentApp] = useState<string | null>(null);
   const [elapsed, setElapsed] = useState(0);
   const [currentUrl, setCurrentUrl] = useState<string | null>(null);
+  const [accessibilityGranted, setAccessibilityGranted] = useState(true);
 
-  // Recovery check on mount
+  // Recovery + 권한 체크 on mount
   useEffect(() => {
     if (recoveryChecked) return;
     setRecoveryChecked(true);
     getIncompleteSession().then((s) => { if (s) setIncompleteSession(s); });
+    checkAccessibilityPermission().then((granted) => setAccessibilityGranted(granted));
   }, [recoveryChecked]);
 
   // Poll stats every 5s when session active
@@ -112,6 +115,14 @@ export function Dropdown() {
 
   return (
     <div className="dropdown">
+      {/* Accessibility 권한 없을 때 안내 배너 */}
+      {!accessibilityGranted && (
+        <div className="dd-permission-banner">
+          <span>⚠️</span>
+          <span>활동 추적을 위해 손쉬운 사용 권한이 필요합니다.</span>
+        </div>
+      )}
+
       {/* Header: timer + focus % */}
       <div className="dd-header">
         <div className="dd-timer">{session ? formatTimer(elapsed) : "--:--"}</div>

--- a/src/services/session.ts
+++ b/src/services/session.ts
@@ -48,3 +48,7 @@ export async function getCurrentUrl(): Promise<string | null> {
 export async function getCurrentTitle(): Promise<string | null> {
   return invoke<string | null>("get_current_title");
 }
+
+export async function checkAccessibilityPermission(): Promise<boolean> {
+  return invoke<boolean>("check_accessibility_permission");
+}


### PR DESCRIPTION
## 개요

스펙의 마지막 두 페이즈를 마무리합니다.

## 변경 사항

### Phase 9: 아카이빙 및 크래시 복구
- **T076**: 앱 시작 시 `archive_old_data()` 자동 호출 — 설정된 `retention_days` 기준 (0=무제한, 아카이빙 스킵)
- T077: Dropdown 미완료 세션 처리 (이전에 구현됨 ✓)

### Phase 10: 권한 처리 + 최종 검증
- **T078**: `check_accessibility_permission` 커맨드 추가 (`AXIsProcessTrusted()` 래핑), Dropdown에 권한 미부여 시 주황색 안내 배너 표시
- **T079**: `browser.rs` Automation 권한 거부 시 stderr 에러 로그 추가 (url=null 동작 기존부터 정상)
- **T080**: Rust 전체 테스트 **80개** 통과
- **T081**: React 전체 테스트 **45개** 통과

## 테스트 결과
```
Rust:  80 passed, 0 failed
React: 45 passed, 0 failed
```

Closes #20