### PR TITLE
[#25] Phase C: Dashboard 강화 - 주간/트렌드 통계 및 인사이트

### DIFF
--- a/specs/001-activity-focus-tracker/tasks.md
+++ b/specs/001-activity-focus-tracker/tasks.md
@@ -271,11 +271,11 @@ Phase 1~10 전체 구현 완료 (2026-03-21). 이하는 v2 확장 Phase.
 
 **목표**: 사용자가 의도를 갖고 세션을 운영할 수 있도록
 
-- [ ] TB001 [P] `src-tauri/migrations/V6__goals.sql`: `session_goals` 테이블 추가 (`target_secs`, `date`)
-- [ ] TB002 [P] `src-tauri/src/commands/goal.rs`: `set_daily_goal(secs)`, `get_daily_goal()`, `get_goal_progress(date)` 커맨드
-- [ ] TB003 [P] `src/components/Dropdown/GoalProgress.tsx`: 목표 시간 설정 + 달성률 프로그레스 바
-- [ ] TB004 [P] `src-tauri/src/services/notification.rs`: `send_notification(title, body)` — macOS 알림 (`tauri-plugin-notification`)
-- [ ] TB005 [P] 세션 루프에 알림 로직 추가: 집중도 임계값(기본 40%) 이하 10분 지속 시 알림, 목표 달성 시 알림
+- [X] TB001 [P] `src-tauri/migrations/V6__goals.sql`: `session_goals` 테이블 추가 (`target_secs`, `date`)
+- [X] TB002 [P] `src-tauri/src/commands/goal.rs`: `set_daily_goal(secs)`, `get_daily_goal()`, `get_goal_progress(date)` 커맨드
+- [X] TB003 [P] `src/components/Dropdown/GoalProgress.tsx`: 목표 시간 설정 + 달성률 프로그레스 바
+- [X] TB004 [P] `src-tauri/src/services/notification.rs`: `send_notification(title, body)` — macOS 알림 (`tauri-plugin-notification`)
+- [X] TB005 [P] 세션 루프에 알림 로직 추가: 집중도 임계값(기본 40%) 이하 10분 지속 시 알림, 목표 달성 시 알림
 
 ---
 
@@ -283,12 +283,12 @@ Phase 1~10 전체 구현 완료 (2026-03-21). 이하는 v2 확장 Phase.
 
 **목표**: 데이터 기반 인사이트 제공
 
-- [ ] TC001 [P] `src-tauri/src/services/activity.rs` 추가: `query_weekly_report(start_date)`, `query_trend(days)` 쿼리
-- [ ] TC002 [P] `src/components/Dashboard/WeeklyReport.tsx`: 요일별 Focus 시간 바 차트 (이번 주 vs 지난 주)
-- [ ] TC003 [P] `src/components/Dashboard/TrendChart.tsx`: 최근 30일 Focus % 꺾은선 그래프
-- [ ] TC004 [P] `src/components/Dashboard/HabitInsights.tsx`: 요일/시간대별 패턴 분석 텍스트 요약
-- [ ] TC005 [P] `src/components/Dashboard/SavedReferences.tsx` 업데이트: 검색 입력창 + 태그 클릭 필터
-- [ ] TC006 `src/pages/Dashboard.tsx` 업데이트: 주간/트렌드 탭 추가, 인사이트 섹션 추가
+- [X] TC001 [P] `src-tauri/src/services/activity.rs` 추가: `query_weekly_report(start_date)`, `query_trend(days)` 쿼리
+- [X] TC002 [P] `src/components/Dashboard/WeeklyReport.tsx`: 요일별 Focus 시간 바 차트 (이번 주 vs 지난 주)
+- [X] TC003 [P] `src/components/Dashboard/TrendChart.tsx`: 최근 30일 Focus % 꺾은선 그래프
+- [X] TC004 [P] `src/components/Dashboard/HabitInsights.tsx`: 요일/시간대별 패턴 분석 텍스트 요약
+- [X] TC005 [P] `src/components/Dashboard/SavedReferences.tsx` 업데이트: 검색 입력창 + 태그 클릭 필터
+- [X] TC006 `src/pages/Dashboard.tsx` 업데이트: 주간/트렌드 탭 추가, 인사이트 섹션 추가
 
 ---
 

--- a/specs/001-activity-focus-tracker/tasks.md
+++ b/specs/001-activity-focus-tracker/tasks.md
@@ -302,6 +302,51 @@ Phase 1~10 전체 구현 완료 (2026-03-21). 이하는 v2 확장 Phase.
 
 ---
 
+## Phase E: 앱 이름 기반 분류 규칙 (Issue #29)
+
+**목표**: 웹사이트뿐 아니라 네이티브 앱(Xcode, Slack 등)도 Focus/Neutral/Distraction으로 분류 가능하게 함
+
+**분류 우선순위 (변경 후)**:
+```
+title_rules (domain+keyword) → domain_rules (domain) → app_rules (app_name) → 내장 기본값 → Neutral
+```
+
+### 백엔드
+
+- [ ] TE001 `src-tauri/migrations/V7__app_rules.sql`: `app_rules` 테이블 생성
+  ```sql
+  CREATE TABLE IF NOT EXISTS app_rules (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    app_name TEXT NOT NULL UNIQUE,
+    category TEXT NOT NULL CHECK (category IN ('Focus', 'Neutral', 'Distraction'))
+  );
+  CREATE INDEX IF NOT EXISTS idx_app_rules_app_name ON app_rules(app_name);
+  ```
+- [ ] TE002 [P] `src-tauri/src/services/classifier.rs` 업데이트: `classify` 함수 시그니처에 `app_rules: &[(String, String)]` 파라미터 추가, 우선순위 적용
+  - `title_rules` → `domain_rules` → `app_rules` → 내장 기본값 → Neutral
+  - TDD: 테스트 먼저 작성 (app_rule 매칭, 우선순위 검증)
+- [ ] TE003 [P] `src-tauri/src/services/activity.rs`: `load_app_rules(pool)` 함수 추가, `poll_once`에서 호출
+- [ ] TE004 [P] `src-tauri/src/commands/activity.rs`: `get_tracked_apps` 커맨드 추가
+  ```sql
+  SELECT DISTINCT app_name FROM activities ORDER BY app_name ASC
+  ```
+- [ ] TE005 [P] `src-tauri/src/commands/settings.rs`: `get_app_rules`, `add_app_rule(app_name, category)`, `delete_app_rule(id)` 커맨드 추가
+- [ ] TE006 `src-tauri/src/lib.rs`: TE005 커맨드 `invoke_handler`에 등록
+
+### 프론트엔드
+
+- [ ] TE007 [P] `src/types/bindings.ts`: `AppRule { id: number; app_name: string; category: string }` 인터페이스 추가
+- [ ] TE008 [P] `src/services/settings.ts`: `getAppRules`, `addAppRule`, `deleteAppRule` 추가
+- [ ] TE009 [P] `src/services/activity.ts`: `getTrackedApps(): Promise<string[]>` 추가
+- [ ] TE010 `src/components/Settings/AppRuleSettings.tsx`: 앱 규칙 설정 컴포넌트 구현
+  - **추적된 앱 목록 선택**: `getTrackedApps()`로 조회한 앱 이름 드롭다운 (이미 규칙 있는 항목 비활성화)
+  - **직접 입력**: 텍스트 입력창으로 앱 이름 수동 입력
+  - Focus / Neutral / Distraction 선택 드롭다운
+  - 추가된 규칙 목록 표시 + 삭제 버튼
+- [ ] TE011 `src/pages/Settings.tsx`: `<AppRuleSettings />` 섹션 추가 (도메인 규칙 섹션 아래)
+
+---
+
 ## 의존성 및 실행 순서
 
 ### Phase 의존성

--- a/src-tauri/src/commands/activity.rs
+++ b/src-tauri/src/commands/activity.rs
@@ -109,6 +109,50 @@ pub async fn get_session_events(
         .collect())
 }
 
+/// 주간 요일별 집중 통계 (start_date: 해당 주 월요일 YYYY-MM-DD)
+#[derive(Debug, serde::Serialize)]
+pub struct WeeklyDayStat {
+    pub date: String,
+    pub focus_secs: i64,
+    pub total_secs: i64,
+}
+
+#[tauri::command]
+pub async fn get_weekly_report(
+    start_date: String,
+    state: State<'_, Mutex<AppState>>,
+) -> Result<Vec<WeeklyDayStat>, AppError> {
+    let pool = get_pool(&state);
+    let rows = activity_svc::query_weekly_report(&pool, &start_date)?;
+    Ok(rows.into_iter().map(|r| WeeklyDayStat {
+        date: r.date,
+        focus_secs: r.focus_secs,
+        total_secs: r.total_secs,
+    }).collect())
+}
+
+/// 최근 N일 집중도 트렌드
+#[derive(Debug, serde::Serialize)]
+pub struct TrendPoint {
+    pub date: String,
+    pub focus_pct: f64,
+    pub focus_secs: i64,
+}
+
+#[tauri::command]
+pub async fn get_trend(
+    days: i64,
+    state: State<'_, Mutex<AppState>>,
+) -> Result<Vec<TrendPoint>, AppError> {
+    let pool = get_pool(&state);
+    let rows = activity_svc::query_trend(&pool, days)?;
+    Ok(rows.into_iter().map(|r| TrendPoint {
+        date: r.date,
+        focus_pct: r.focus_pct,
+        focus_secs: r.focus_secs,
+    }).collect())
+}
+
 /// 특정 날짜(UTC)의 Focus/Neutral/Distraction 일별 통계
 #[tauri::command]
 pub async fn get_daily_focus_stats(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -220,6 +220,8 @@ pub fn run() {
             commands::activity::get_top_sites,
             commands::activity::get_daily_focus_stats,
             commands::activity::get_session_events,
+            commands::activity::get_weekly_report,
+            commands::activity::get_trend,
             commands::settings::get_settings,
             commands::settings::update_settings,
             commands::settings::get_classification_rules,

--- a/src-tauri/src/services/activity.rs
+++ b/src-tauri/src/services/activity.rs
@@ -184,3 +184,75 @@ pub fn query_daily_focus_stats(pool: &DbPool, date: &str) -> Result<DailyFocusSt
     let total_secs = focus_secs + neutral_secs + distraction_secs;
     Ok(DailyFocusStats { total_secs, focus_secs, neutral_secs, distraction_secs })
 }
+
+pub struct WeeklyDayStat {
+    pub date: String,       // YYYY-MM-DD
+    pub focus_secs: i64,
+    pub total_secs: i64,
+}
+
+/// 특정 주(월~일)의 요일별 집중 통계 조회
+/// start_date: 해당 주 월요일 (YYYY-MM-DD)
+pub fn query_weekly_report(pool: &DbPool, start_date: &str) -> Result<Vec<WeeklyDayStat>, AppError> {
+    let conn = pool.get().map_err(AppError::from)?;
+    let mut stmt = conn.prepare(
+        "SELECT date(s.started_at, 'unixepoch') as day,
+                SUM(CASE WHEN a.classification = 'Focus' THEN a.duration_secs ELSE 0 END) as focus_secs,
+                SUM(a.duration_secs) as total_secs
+         FROM activities a
+         JOIN sessions s ON a.session_id = s.id
+         WHERE day >= ?1 AND day < date(?1, '+7 days')
+           AND a.duration_secs IS NOT NULL
+         GROUP BY day
+         ORDER BY day ASC"
+    ).map_err(AppError::from)?;
+
+    let rows = stmt.query_map(rusqlite::params![start_date], |r| {
+        Ok(WeeklyDayStat {
+            date: r.get(0)?,
+            focus_secs: r.get(1)?,
+            total_secs: r.get(2)?,
+        })
+    })
+    .map_err(AppError::from)?
+    .filter_map(|r| r.ok())
+    .collect();
+
+    Ok(rows)
+}
+
+pub struct TrendPoint {
+    pub date: String,
+    pub focus_pct: f64,
+    pub focus_secs: i64,
+}
+
+/// 최근 N일간 일별 집중도 트렌드
+pub fn query_trend(pool: &DbPool, days: i64) -> Result<Vec<TrendPoint>, AppError> {
+    let conn = pool.get().map_err(AppError::from)?;
+    let mut stmt = conn.prepare(
+        "SELECT date(s.started_at, 'unixepoch') as day,
+                CAST(SUM(CASE WHEN a.classification = 'Focus' THEN a.duration_secs ELSE 0 END) AS REAL)
+                  / NULLIF(SUM(a.duration_secs), 0) * 100.0 as focus_pct,
+                SUM(CASE WHEN a.classification = 'Focus' THEN a.duration_secs ELSE 0 END) as focus_secs
+         FROM activities a
+         JOIN sessions s ON a.session_id = s.id
+         WHERE day >= date('now', '-' || ?1 || ' days')
+           AND a.duration_secs IS NOT NULL
+         GROUP BY day
+         ORDER BY day ASC"
+    ).map_err(AppError::from)?;
+
+    let rows = stmt.query_map(rusqlite::params![days], |r| {
+        Ok(TrendPoint {
+            date: r.get(0)?,
+            focus_pct: r.get::<_, Option<f64>>(1)?.unwrap_or(0.0),
+            focus_secs: r.get(2)?,
+        })
+    })
+    .map_err(AppError::from)?
+    .filter_map(|r| r.ok())
+    .collect();
+
+    Ok(rows)
+}

--- a/src/components/Dashboard/HabitInsights.tsx
+++ b/src/components/Dashboard/HabitInsights.tsx
@@ -1,0 +1,110 @@
+import { useEffect, useState } from "react";
+import { getTrend, type TrendPoint } from "../../services/stats";
+
+const DAY_KR = ["일", "월", "화", "수", "목", "금", "토"];
+
+function formatHours(secs: number): string {
+  const h = Math.floor(secs / 3600);
+  const m = Math.floor((secs % 3600) / 60);
+  if (h === 0) return `${m}분`;
+  return m > 0 ? `${h}시간 ${m}분` : `${h}시간`;
+}
+
+function analyzeInsights(points: TrendPoint[]) {
+  if (points.length === 0) return null;
+
+  // Average focus %
+  const avgPct = points.reduce((s, p) => s + p.focus_pct, 0) / points.length;
+
+  // Best & worst day
+  const best = points.reduce((a, b) => (a.focus_pct > b.focus_pct ? a : b));
+  const worst = points.reduce((a, b) => (a.focus_pct < b.focus_pct ? a : b));
+
+  // Day-of-week aggregation
+  const dayBuckets: { sum: number; count: number }[] = Array.from(
+    { length: 7 },
+    () => ({ sum: 0, count: 0 })
+  );
+  for (const p of points) {
+    const dow = new Date(p.date).getDay();
+    dayBuckets[dow].sum += p.focus_pct;
+    dayBuckets[dow].count += 1;
+  }
+  const dayAvg = dayBuckets.map((b) => (b.count > 0 ? b.sum / b.count : -1));
+  const validDays = dayAvg.map((a, i) => ({ avg: a, i })).filter((d) => d.avg >= 0);
+  const bestDow = validDays.length > 0
+    ? validDays.reduce((a, b) => (a.avg > b.avg ? a : b))
+    : null;
+
+  // Current streak (consecutive days with focus_pct >= 50)
+  let streak = 0;
+  for (let i = points.length - 1; i >= 0; i--) {
+    if (points[i].focus_pct >= 50) streak++;
+    else break;
+  }
+
+  // Total focus time
+  const totalFocusSecs = points.reduce((s, p) => s + p.focus_secs, 0);
+
+  return { avgPct, best, worst, bestDow, streak, totalFocusSecs };
+}
+
+export function HabitInsights() {
+  const [points, setPoints] = useState<TrendPoint[]>([]);
+
+  useEffect(() => {
+    getTrend(30).then(setPoints);
+  }, []);
+
+  const insights = analyzeInsights(points);
+
+  if (!insights) {
+    return <p className="dash-empty">최근 30일 데이터가 없습니다</p>;
+  }
+
+  const { avgPct, best, bestDow, streak, totalFocusSecs } = insights;
+
+  return (
+    <div className="habit-insights">
+      <h3 className="habit-insights__title">30일 패턴 분석</h3>
+
+      <div className="habit-insights__grid">
+        <div className="habit-card">
+          <div className="habit-card__value">{avgPct.toFixed(0)}%</div>
+          <div className="habit-card__label">평균 Focus율</div>
+        </div>
+
+        <div className="habit-card">
+          <div className="habit-card__value">{formatHours(totalFocusSecs)}</div>
+          <div className="habit-card__label">총 집중 시간</div>
+        </div>
+
+        <div className="habit-card">
+          <div className="habit-card__value">{streak}일</div>
+          <div className="habit-card__label">Focus 연속 달성</div>
+          <div className="habit-card__sub">(50% 이상)</div>
+        </div>
+
+        {bestDow && (
+          <div className="habit-card">
+            <div className="habit-card__value">{DAY_KR[bestDow.i]}요일</div>
+            <div className="habit-card__label">가장 집중한 요일</div>
+            <div className="habit-card__sub">{bestDow.avg.toFixed(0)}% 평균</div>
+          </div>
+        )}
+      </div>
+
+      {best.focus_pct > 0 && (
+        <div className="habit-insights__best">
+          <span className="habit-insights__best-label">최고 기록</span>
+          <span className="habit-insights__best-date">
+            {new Date(best.date).toLocaleDateString("ko-KR")}
+          </span>
+          <span className="habit-insights__best-pct">
+            {best.focus_pct.toFixed(0)}%
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/Dashboard/SavedReferences.tsx
+++ b/src/components/Dashboard/SavedReferences.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useMemo } from "react";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import type { Reference } from "../../types/bindings";
 import { deleteReference, updateReference } from "../../services/reference";
@@ -26,6 +26,27 @@ interface EditState {
 export function SavedReferences({ references, onRefresh }: Props) {
   const [editing, setEditing] = useState<EditState | null>(null);
   const [saving, setSaving] = useState(false);
+  const [search, setSearch] = useState("");
+  const [activeTag, setActiveTag] = useState<string | null>(null);
+
+  const allTags = useMemo(() => {
+    const set = new Set<string>();
+    for (const ref of references) {
+      for (const tag of ref.tags) set.add(tag);
+    }
+    return Array.from(set).sort();
+  }, [references]);
+
+  const filtered = useMemo(() => {
+    return references.filter((ref) => {
+      const matchesSearch =
+        !search ||
+        ref.title.toLowerCase().includes(search.toLowerCase()) ||
+        ref.url.toLowerCase().includes(search.toLowerCase());
+      const matchesTag = !activeTag || ref.tags.includes(activeTag);
+      return matchesSearch && matchesTag;
+    });
+  }, [references, search, activeTag]);
 
   const handleOpen = async (url: string) => {
     try {
@@ -69,7 +90,40 @@ export function SavedReferences({ references, onRefresh }: Props) {
 
   return (
     <div className="saved-refs">
-      {references.map((ref) => {
+      <div className="saved-refs__filters">
+        <input
+          className="saved-refs__search"
+          type="text"
+          placeholder="제목 또는 URL 검색..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+        />
+        {allTags.length > 0 && (
+          <div className="saved-refs__tags">
+            <button
+              className={`saved-ref-tag saved-ref-tag--filter${activeTag === null ? " active" : ""}`}
+              onClick={() => setActiveTag(null)}
+            >
+              전체
+            </button>
+            {allTags.map((tag) => (
+              <button
+                key={tag}
+                className={`saved-ref-tag saved-ref-tag--filter${activeTag === tag ? " active" : ""}`}
+                onClick={() => setActiveTag(activeTag === tag ? null : tag)}
+              >
+                {tag}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {filtered.length === 0 && (
+        <p className="dash-empty">검색 결과 없음</p>
+      )}
+
+      {filtered.map((ref) => {
         const isEditing = editing?.id === ref.id;
         return (
           <div key={ref.id} className="saved-ref-item">

--- a/src/components/Dashboard/TrendChart.tsx
+++ b/src/components/Dashboard/TrendChart.tsx
@@ -1,0 +1,145 @@
+import { useEffect, useState } from "react";
+import { getTrend, type TrendPoint } from "../../services/stats";
+
+function formatDate(dateStr: string): string {
+  const d = new Date(dateStr);
+  return `${d.getMonth() + 1}/${d.getDate()}`;
+}
+
+export function TrendChart() {
+  const [points, setPoints] = useState<TrendPoint[]>([]);
+
+  useEffect(() => {
+    getTrend(30).then(setPoints);
+  }, []);
+
+  if (points.length === 0) {
+    return <p className="dash-empty">최근 30일 데이터가 없습니다</p>;
+  }
+
+  const W = 560;
+  const H = 180;
+  const PAD = { top: 16, right: 16, bottom: 32, left: 36 };
+  const chartW = W - PAD.left - PAD.right;
+  const chartH = H - PAD.top - PAD.bottom;
+
+  const maxPct = 100;
+  const xStep = points.length > 1 ? chartW / (points.length - 1) : chartW;
+
+  const toX = (i: number) => PAD.left + i * xStep;
+  const toY = (pct: number) => PAD.top + chartH - (pct / maxPct) * chartH;
+
+  const polyline = points
+    .map((p, i) => `${toX(i)},${toY(p.focus_pct)}`)
+    .join(" ");
+
+  // area fill path
+  const areaPath = [
+    `M ${toX(0)},${toY(points[0].focus_pct)}`,
+    ...points.slice(1).map((p, i) => `L ${toX(i + 1)},${toY(p.focus_pct)}`),
+    `L ${toX(points.length - 1)},${PAD.top + chartH}`,
+    `L ${toX(0)},${PAD.top + chartH}`,
+    "Z",
+  ].join(" ");
+
+  // Y-axis ticks
+  const yTicks = [0, 25, 50, 75, 100];
+
+  // X-axis labels: show first, middle, last
+  const xLabelIndices = new Set([
+    0,
+    Math.floor((points.length - 1) / 2),
+    points.length - 1,
+  ]);
+
+  const avgPct =
+    points.reduce((s, p) => s + p.focus_pct, 0) / points.length;
+
+  return (
+    <div className="trend-chart">
+      <div className="trend-chart__header">
+        <span className="trend-chart__title">최근 30일 Focus 추이</span>
+        <span className="trend-chart__avg">평균 {avgPct.toFixed(0)}%</span>
+      </div>
+
+      <svg
+        viewBox={`0 0 ${W} ${H}`}
+        width="100%"
+        className="trend-chart__svg"
+      >
+        <defs>
+          <linearGradient id="trend-fill" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor="#0a84ff" stopOpacity="0.3" />
+            <stop offset="100%" stopColor="#0a84ff" stopOpacity="0" />
+          </linearGradient>
+        </defs>
+
+        {/* Y-axis grid lines */}
+        {yTicks.map((tick) => (
+          <g key={tick}>
+            <line
+              x1={PAD.left}
+              y1={toY(tick)}
+              x2={W - PAD.right}
+              y2={toY(tick)}
+              stroke="#333"
+              strokeWidth={0.5}
+              strokeDasharray="3,3"
+            />
+            <text
+              x={PAD.left - 6}
+              y={toY(tick) + 4}
+              textAnchor="end"
+              fontSize={9}
+              fill="#888"
+            >
+              {tick}%
+            </text>
+          </g>
+        ))}
+
+        {/* Area fill */}
+        <path d={areaPath} fill="url(#trend-fill)" />
+
+        {/* Line */}
+        <polyline
+          points={polyline}
+          fill="none"
+          stroke="#0a84ff"
+          strokeWidth={2}
+          strokeLinejoin="round"
+          strokeLinecap="round"
+        />
+
+        {/* Data points */}
+        {points.map((p, i) => (
+          <circle
+            key={p.date}
+            cx={toX(i)}
+            cy={toY(p.focus_pct)}
+            r={3}
+            fill="#0a84ff"
+          >
+            <title>{`${p.date}: ${p.focus_pct.toFixed(0)}%`}</title>
+          </circle>
+        ))}
+
+        {/* X-axis labels */}
+        {points.map((p, i) =>
+          xLabelIndices.has(i) ? (
+            <text
+              key={p.date}
+              x={toX(i)}
+              y={H - 4}
+              textAnchor="middle"
+              fontSize={9}
+              fill="#888"
+            >
+              {formatDate(p.date)}
+            </text>
+          ) : null
+        )}
+      </svg>
+    </div>
+  );
+}

--- a/src/components/Dashboard/WeeklyReport.tsx
+++ b/src/components/Dashboard/WeeklyReport.tsx
@@ -1,0 +1,77 @@
+import { useEffect, useState } from "react";
+import { getWeeklyReport, type WeeklyDayStat } from "../../services/stats";
+
+const DAY_LABELS = ["월", "화", "수", "목", "금", "토", "일"];
+
+function getMonday(date: Date): string {
+  const d = new Date(date);
+  const day = d.getDay();
+  const diff = day === 0 ? -6 : 1 - day;
+  d.setDate(d.getDate() + diff);
+  return d.toISOString().slice(0, 10);
+}
+
+function formatHours(secs: number): string {
+  const h = Math.floor(secs / 3600);
+  const m = Math.floor((secs % 3600) / 60);
+  if (h === 0) return `${m}m`;
+  return m > 0 ? `${h}h ${m}m` : `${h}h`;
+}
+
+interface Props {
+  weekOffset?: number; // 0 = 이번주, -1 = 지난주
+}
+
+export function WeeklyReport({ weekOffset = 0 }: Props) {
+  const [stats, setStats] = useState<WeeklyDayStat[]>([]);
+  const [startDate, setStartDate] = useState("");
+
+  useEffect(() => {
+    const base = new Date();
+    base.setDate(base.getDate() + weekOffset * 7);
+    const monday = getMonday(base);
+    setStartDate(monday);
+    getWeeklyReport(monday).then(setStats);
+  }, [weekOffset]);
+
+  // 7일 슬롯 생성 (데이터 없는 날은 0으로)
+  const slots = Array.from({ length: 7 }, (_, i) => {
+    const d = new Date(startDate);
+    d.setDate(d.getDate() + i);
+    const dateStr = d.toISOString().slice(0, 10);
+    const found = stats.find((s) => s.date === dateStr);
+    return { label: DAY_LABELS[i], date: dateStr, focus_secs: found?.focus_secs ?? 0 };
+  });
+
+  const maxSecs = Math.max(...slots.map((s) => s.focus_secs), 1);
+  const today = new Date().toISOString().slice(0, 10);
+
+  return (
+    <div className="weekly-report">
+      <div className="weekly-report__bars">
+        {slots.map((slot) => {
+          const pct = (slot.focus_secs / maxSecs) * 100;
+          const isToday = slot.date === today;
+          return (
+            <div key={slot.date} className="weekly-report__col">
+              <div className="weekly-report__bar-wrap">
+                <div
+                  className="weekly-report__bar"
+                  style={{
+                    height: `${pct}%`,
+                    background: isToday ? "#30d158" : "#0a84ff",
+                    opacity: slot.focus_secs === 0 ? 0.2 : 1,
+                  }}
+                  title={slot.focus_secs > 0 ? formatHours(slot.focus_secs) : "기록 없음"}
+                />
+              </div>
+              <span className={`weekly-report__day${isToday ? " today" : ""}`}>
+                {slot.label}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -7,6 +7,9 @@ import { TopSites } from "../components/Dashboard/TopSites";
 import { FocusScore } from "../components/Dashboard/FocusScore";
 import { SavedReferences } from "../components/Dashboard/SavedReferences";
 import { DatePicker } from "../components/Dashboard/DatePicker";
+import { WeeklyReport } from "../components/Dashboard/WeeklyReport";
+import { TrendChart } from "../components/Dashboard/TrendChart";
+import { HabitInsights } from "../components/Dashboard/HabitInsights";
 
 function todayDateStr(): string {
   return new Date().toISOString().split("T")[0];
@@ -18,8 +21,7 @@ function shiftDate(dateStr: string, days: number): string {
   return d.toISOString().split("T")[0];
 }
 
-
-type Tab = "timeline" | "sites" | "score" | "refs";
+type Tab = "timeline" | "sites" | "score" | "refs" | "weekly" | "trend";
 
 export function Dashboard() {
   const [date, setDate] = useState(todayDateStr);
@@ -59,31 +61,38 @@ export function Dashboard() {
     { id: "timeline", label: "타임라인" },
     { id: "sites", label: "Top Sites" },
     { id: "score", label: "Focus Score" },
+    { id: "weekly", label: "주간 리포트" },
+    { id: "trend", label: "트렌드" },
     { id: "refs", label: "References" },
   ];
+
+  // Date nav only relevant for day-based tabs
+  const isDayTab = tab === "timeline" || tab === "sites" || tab === "score";
 
   return (
     <div className="dashboard">
       <div className="dash-header">
         <h1 className="dash-title">Dashboard</h1>
-        <div className="dash-date-nav">
-          <button
-            className="dash-date-btn"
-            onClick={() => setDate((d) => shiftDate(d, -1))}
-            aria-label="이전 날"
-          >
-            ‹
-          </button>
-          <DatePicker value={date} max={todayDateStr()} onChange={setDate} />
-          <button
-            className="dash-date-btn"
-            onClick={() => setDate((d) => shiftDate(d, 1))}
-            disabled={date >= todayDateStr()}
-            aria-label="다음 날"
-          >
-            ›
-          </button>
-        </div>
+        {isDayTab && (
+          <div className="dash-date-nav">
+            <button
+              className="dash-date-btn"
+              onClick={() => setDate((d) => shiftDate(d, -1))}
+              aria-label="이전 날"
+            >
+              ‹
+            </button>
+            <DatePicker value={date} max={todayDateStr()} onChange={setDate} />
+            <button
+              className="dash-date-btn"
+              onClick={() => setDate((d) => shiftDate(d, 1))}
+              disabled={date >= todayDateStr()}
+              aria-label="다음 날"
+            >
+              ›
+            </button>
+          </div>
+        )}
       </div>
 
       <div className="dash-tabs">
@@ -99,13 +108,31 @@ export function Dashboard() {
       </div>
 
       <div className="dash-content">
-        {loading ? (
+        {loading && isDayTab ? (
           <p className="dash-loading">로딩 중...</p>
         ) : (
           <>
             {tab === "timeline" && <ActivityTimeline activities={activities} sessionEvents={sessionEvents} />}
             {tab === "sites" && <TopSites sites={sites} />}
             {tab === "score" && <FocusScore metrics={metrics} />}
+            {tab === "weekly" && (
+              <div className="weekly-section">
+                <div className="weekly-section__block">
+                  <h3 className="weekly-section__subtitle">이번 주</h3>
+                  <WeeklyReport weekOffset={0} />
+                </div>
+                <div className="weekly-section__block">
+                  <h3 className="weekly-section__subtitle">지난 주</h3>
+                  <WeeklyReport weekOffset={-1} />
+                </div>
+              </div>
+            )}
+            {tab === "trend" && (
+              <div className="trend-section">
+                <TrendChart />
+                <HabitInsights />
+              </div>
+            )}
             {tab === "refs" && (
               <SavedReferences
                 references={refs}

--- a/src/services/stats.ts
+++ b/src/services/stats.ts
@@ -1,0 +1,21 @@
+import { invoke } from "@tauri-apps/api/core";
+
+export interface WeeklyDayStat {
+  date: string;
+  focus_secs: number;
+  total_secs: number;
+}
+
+export interface TrendPoint {
+  date: string;
+  focus_pct: number;
+  focus_secs: number;
+}
+
+export async function getWeeklyReport(startDate: string): Promise<WeeklyDayStat[]> {
+  return invoke<WeeklyDayStat[]>("get_weekly_report", { startDate });
+}
+
+export async function getTrend(days: number): Promise<TrendPoint[]> {
+  return invoke<TrendPoint[]>("get_trend", { days });
+}


### PR DESCRIPTION
## Summary

- `query_weekly_report` / `query_trend` Rust 서비스 + Tauri 커맨드 추가
- `WeeklyReport`: 이번 주 / 지난 주 요일별 Focus 바 차트
- `TrendChart`: 최근 30일 Focus % SVG 꺾은선 그래프
- `HabitInsights`: 평균 Focus율, 총 집중시간, 연속 달성일, 베스트 요일 카드
- `SavedReferences`: 제목/URL 검색 + 태그 클릭 필터
- `Dashboard`: 주간/트렌드 탭 추가, 날짜 네비게이션 조건부 표시

## Test plan

- [ ] Dashboard → 주간 리포트 탭: 이번 주 / 지난 주 바 차트 렌더링 확인
- [ ] Dashboard → 트렌드 탭: 꺾은선 그래프 + 인사이트 카드 렌더링 확인
- [ ] References 탭: 검색어 입력 시 필터링 동작 확인
- [ ] References 탭: 태그 버튼 클릭 시 필터링 + 전체 버튼으로 해제 확인
- [ ] `cargo check` 및 `tsc --noEmit` 통과 확인

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)