### PR TITLE
[#26] Phase D: 데이터 내보내기 + 대시보드 버그 수정 및 UI 개선

### DIFF
--- a/specs/001-activity-focus-tracker/tasks.md
+++ b/specs/001-activity-focus-tracker/tasks.md
@@ -296,9 +296,9 @@ Phase 1~10 전체 구현 완료 (2026-03-21). 이하는 v2 확장 Phase.
 
 **목표**: 데이터 주권 + 외부 활용
 
-- [ ] TD001 [P] `src-tauri/src/commands/export.rs`: `export_data(start_date, end_date, format)` — CSV/JSON 생성 후 파일 저장 다이얼로그
-- [ ] TD002 [P] `src/components/Dashboard/ExportButton.tsx`: 날짜 범위 선택 + 형식 선택 (CSV/JSON) + 내보내기 버튼
-- [ ] TD003 `src/pages/Dashboard.tsx` 업데이트: ExportButton 추가
+- [x] TD001 [P] `src-tauri/src/commands/export.rs`: `export_data(start_date, end_date, format)` — CSV/JSON 생성 후 Downloads 폴더 저장 + opener로 폴더 열기
+- [x] TD002 [P] `src/components/Dashboard/ExportButton.tsx`: 날짜 범위 선택 + 형식 선택 (CSV/JSON) + 내보내기 버튼
+- [x] TD003 `src/pages/Dashboard.tsx` 업데이트: ExportButton 추가
 
 ---
 

--- a/src-tauri/src/commands/export.rs
+++ b/src-tauri/src/commands/export.rs
@@ -1,0 +1,104 @@
+use std::sync::Mutex;
+use tauri::{AppHandle, Manager, State};
+
+use crate::errors::AppError;
+use crate::services::{activity as activity_svc, db::DbPool};
+use crate::state::app_state::AppState;
+
+fn get_pool(state: &State<'_, Mutex<AppState>>) -> DbPool {
+    state.lock().unwrap().db_pool.clone()
+}
+
+fn format_csv(rows: &[activity_svc::ActivityRow]) -> String {
+    let mut out = String::from(
+        "date,app_name,domain,title,classification,duration_secs,url\n",
+    );
+    for r in rows {
+        let domain = r.domain.as_deref().unwrap_or("");
+        let url = r.url.as_deref().unwrap_or("");
+        let title = r.title.as_deref().unwrap_or("");
+        let duration = r.duration_secs.unwrap_or(0);
+        // Escape fields that may contain commas/quotes
+        let escape = |s: &str| {
+            if s.contains(',') || s.contains('"') || s.contains('\n') {
+                format!("\"{}\"", s.replace('"', "\"\""))
+            } else {
+                s.to_string()
+            }
+        };
+        out.push_str(&format!(
+            "{},{},{},{},{},{},{}\n",
+            &r.started_at[..10],
+            escape(&r.app_name),
+            escape(domain),
+            escape(title),
+            r.classification,
+            duration,
+            escape(url),
+        ));
+    }
+    out
+}
+
+fn format_json(rows: &[activity_svc::ActivityRow]) -> Result<String, AppError> {
+    #[derive(serde::Serialize)]
+    struct ExportRow<'a> {
+        date: &'a str,
+        app_name: &'a str,
+        domain: Option<&'a str>,
+        title: Option<&'a str>,
+        classification: &'a str,
+        duration_secs: Option<i64>,
+        url: Option<&'a str>,
+    }
+
+    let items: Vec<ExportRow> = rows
+        .iter()
+        .map(|r| ExportRow {
+            date: &r.started_at[..10],
+            app_name: &r.app_name,
+            domain: r.domain.as_deref(),
+            title: r.title.as_deref(),
+            classification: &r.classification,
+            duration_secs: r.duration_secs,
+            url: r.url.as_deref(),
+        })
+        .collect();
+
+    serde_json::to_string_pretty(&items).map_err(|e| AppError::Internal(e.to_string()))
+}
+
+#[tauri::command]
+pub async fn export_data(
+    start_date: String,
+    end_date: String,
+    format: String,
+    state: State<'_, Mutex<AppState>>,
+    app: AppHandle,
+) -> Result<String, AppError> {
+    let pool = get_pool(&state);
+    let rows = activity_svc::query_export_activities(&pool, &start_date, &end_date)?;
+
+    if rows.is_empty() {
+        return Err(AppError::NotFound("해당 기간에 활동 데이터가 없습니다".into()));
+    }
+
+    let (content, ext) = match format.as_str() {
+        "json" => (format_json(&rows)?, "json"),
+        _ => (format_csv(&rows), "csv"),
+    };
+
+    let downloads = app
+        .path()
+        .download_dir()
+        .map_err(|e| AppError::Internal(e.to_string()))?;
+
+    let timestamp = chrono::Local::now().format("%Y%m%d-%H%M%S");
+    let filename = format!("focaro-export-{}-to-{}-{}.{}", start_date, end_date, timestamp, ext);
+    let full_path = downloads.join(&filename);
+
+    std::fs::write(&full_path, content)
+        .map_err(|e| AppError::Internal(e.to_string()))?;
+
+    Ok(full_path.to_string_lossy().to_string())
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod activity;
+pub mod export;
 pub mod goal;
 pub mod onboarding;
 pub mod reference;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -239,6 +239,7 @@ pub fn run() {
             commands::onboarding::add_title_rule,
             commands::onboarding::delete_title_rule,
             commands::onboarding::override_activity_classification,
+            commands::export::export_data,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/services/activity.rs
+++ b/src-tauri/src/services/activity.rs
@@ -256,3 +256,43 @@ pub fn query_trend(pool: &DbPool, days: i64) -> Result<Vec<TrendPoint>, AppError
 
     Ok(rows)
 }
+
+/// 날짜 범위 활동 내보내기용 전체 조회
+pub fn query_export_activities(
+    pool: &DbPool,
+    start_date: &str,
+    end_date: &str,
+) -> Result<Vec<ActivityRow>, AppError> {
+    let conn = pool.get().map_err(AppError::from)?;
+    let mut stmt = conn
+        .prepare(
+            "SELECT id, session_id, app_name, url, domain, classification, started_at, duration_secs, title
+             FROM activities
+             WHERE date(started_at, 'unixepoch') >= ?1
+               AND date(started_at, 'unixepoch') <= ?2
+               AND duration_secs IS NOT NULL
+             ORDER BY started_at ASC",
+        )
+        .map_err(AppError::from)?;
+
+    let rows = stmt
+        .query_map(rusqlite::params![start_date, end_date], |r| {
+            let ts: i64 = r.get(6)?;
+            Ok(ActivityRow {
+                id: r.get(0)?,
+                session_id: r.get(1)?,
+                app_name: r.get(2)?,
+                url: r.get(3)?,
+                domain: r.get(4)?,
+                title: r.get(8)?,
+                classification: r.get(5)?,
+                started_at: unix_to_iso(ts),
+                duration_secs: r.get(7)?,
+            })
+        })
+        .map_err(AppError::from)?
+        .filter_map(|r| r.ok())
+        .collect();
+
+    Ok(rows)
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -26,38 +26,43 @@
       },
       {
         "label": "dashboard",
-        "title": "focaro Dashboard",
+        "title": "",
         "width": 900,
         "height": 650,
         "visible": false,
-        "resizable": true
+        "resizable": true,
+        "titleBarStyle": "overlay",
+        "hiddenTitle": true
       },
       {
         "label": "save-reference",
-        "title": "Reference 저장",
+        "title": "",
         "width": 480,
         "height": 280,
         "visible": false,
         "resizable": false,
-        "decorations": true
+        "titleBarStyle": "overlay",
+        "hiddenTitle": true
       },
       {
         "label": "settings",
-        "title": "focaro 설정",
+        "title": "",
         "width": 600,
         "height": 500,
         "visible": false,
         "resizable": false,
-        "decorations": true
+        "titleBarStyle": "overlay",
+        "hiddenTitle": true
       },
       {
         "label": "onboarding",
-        "title": "focaro 시작하기",
+        "title": "",
         "width": 520,
         "height": 460,
         "visible": false,
         "resizable": false,
-        "decorations": true,
+        "titleBarStyle": "overlay",
+        "hiddenTitle": true,
         "center": true
       }
     ],

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -31,7 +31,7 @@
         "height": 650,
         "visible": false,
         "resizable": true,
-        "titleBarStyle": "overlay",
+        "titleBarStyle": "Overlay",
         "hiddenTitle": true
       },
       {
@@ -41,7 +41,7 @@
         "height": 280,
         "visible": false,
         "resizable": false,
-        "titleBarStyle": "overlay",
+        "titleBarStyle": "Overlay",
         "hiddenTitle": true
       },
       {
@@ -51,7 +51,7 @@
         "height": 500,
         "visible": false,
         "resizable": false,
-        "titleBarStyle": "overlay",
+        "titleBarStyle": "Overlay",
         "hiddenTitle": true
       },
       {
@@ -61,7 +61,7 @@
         "height": 460,
         "visible": false,
         "resizable": false,
-        "titleBarStyle": "overlay",
+        "titleBarStyle": "Overlay",
         "hiddenTitle": true,
         "center": true
       }

--- a/src/App.css
+++ b/src/App.css
@@ -1483,3 +1483,466 @@ body {
   font-weight: 600;
   cursor: pointer;
 }
+
+/* ── titleBarStyle: overlay — 트래픽 라이트 영역 패딩 & 드래그 ── */
+
+.dashboard {
+  padding-top: 28px;
+}
+
+.dash-header {
+  -webkit-app-region: drag;
+  padding-top: 8px;
+}
+
+.dash-header button,
+.dash-header input,
+.dash-header-actions {
+  -webkit-app-region: no-drag;
+}
+
+.settings-page {
+  padding-top: 44px;
+}
+
+.save-ref-page {
+  padding-top: 44px;
+}
+
+.onboarding {
+  padding-top: 44px;
+}
+
+/* ── 대시보드 헤더 액션 영역 ── */
+
+.dash-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+/* ── ErrorBoundary ── */
+
+.dash-error {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  padding: 48px 0;
+  color: #636366;
+  font-size: 13px;
+}
+
+/* ── Export 버튼 & 패널 ── */
+
+.export-trigger {
+  background: rgba(255,255,255,0.07);
+  border: 1px solid rgba(255,255,255,0.12);
+  border-radius: 8px;
+  color: #ebebf5cc;
+  font-size: 12px;
+  font-weight: 500;
+  padding: 5px 12px;
+  cursor: pointer;
+  transition: background 0.15s;
+  white-space: nowrap;
+}
+
+.export-trigger:hover {
+  background: rgba(255,255,255,0.12);
+}
+
+.export-panel {
+  position: relative;
+  background: #1c1c1e;
+  border: 1px solid rgba(255,255,255,0.1);
+  border-radius: 12px;
+  padding: 16px;
+  width: 280px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  box-shadow: 0 8px 32px rgba(0,0,0,0.6);
+  -webkit-app-region: no-drag;
+}
+
+.export-panel__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.export-panel__title {
+  font-size: 13px;
+  font-weight: 600;
+  color: #fff;
+}
+
+.export-panel__close {
+  background: transparent;
+  border: none;
+  color: #636366;
+  font-size: 14px;
+  cursor: pointer;
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+
+.export-panel__close:hover {
+  color: #ebebf5;
+  background: rgba(255,255,255,0.08);
+}
+
+.export-panel__row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.export-panel__label {
+  font-size: 12px;
+  color: #8e8e93;
+  width: 40px;
+  flex-shrink: 0;
+}
+
+.export-panel__input {
+  flex: 1;
+  background: rgba(255,255,255,0.07);
+  border: 1px solid rgba(255,255,255,0.1);
+  border-radius: 7px;
+  color: #ebebf5;
+  font-size: 12px;
+  padding: 5px 8px;
+  color-scheme: dark;
+}
+
+.export-panel__input:focus {
+  outline: none;
+  border-color: #0a84ff;
+}
+
+.export-panel__formats {
+  display: flex;
+  gap: 6px;
+}
+
+.export-format-btn {
+  background: rgba(255,255,255,0.06);
+  border: 1px solid rgba(255,255,255,0.1);
+  border-radius: 6px;
+  color: #8e8e93;
+  font-size: 11px;
+  font-weight: 600;
+  padding: 4px 10px;
+  cursor: pointer;
+  letter-spacing: 0.05em;
+  transition: all 0.15s;
+}
+
+.export-format-btn--active {
+  background: rgba(10,132,255,0.18);
+  border-color: #0a84ff;
+  color: #0a84ff;
+}
+
+.export-panel__btn {
+  background: #0a84ff;
+  border: none;
+  border-radius: 8px;
+  color: #fff;
+  font-size: 13px;
+  font-weight: 600;
+  padding: 8px 0;
+  cursor: pointer;
+  transition: opacity 0.15s;
+}
+
+.export-panel__btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.export-panel__success {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: rgba(48,209,88,0.12);
+  border: 1px solid rgba(48,209,88,0.25);
+  border-radius: 8px;
+  padding: 8px 10px;
+  font-size: 12px;
+  color: #30d158;
+}
+
+.export-panel__reveal {
+  background: transparent;
+  border: none;
+  color: #30d158;
+  font-size: 11px;
+  font-weight: 600;
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.export-panel__error {
+  font-size: 11px;
+  color: #ff453a;
+  margin: 0;
+  padding: 6px 8px;
+  background: rgba(255,69,58,0.1);
+  border-radius: 6px;
+}
+
+/* ── Weekly Report ── */
+
+.weekly-section {
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+}
+
+.weekly-section__block {
+  background: rgba(255,255,255,0.03);
+  border: 1px solid rgba(255,255,255,0.07);
+  border-radius: 12px;
+  padding: 16px 20px;
+}
+
+.weekly-section__subtitle {
+  font-size: 13px;
+  font-weight: 600;
+  color: #8e8e93;
+  margin: 0 0 14px;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+.weekly-report {
+  width: 100%;
+}
+
+.weekly-report__bars {
+  display: flex;
+  align-items: flex-end;
+  gap: 8px;
+  height: 100px;
+  padding-bottom: 24px;
+  position: relative;
+}
+
+.weekly-report__col {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  height: 100%;
+}
+
+.weekly-report__bar-wrap {
+  flex: 1;
+  width: 100%;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+}
+
+.weekly-report__bar {
+  width: 100%;
+  max-width: 36px;
+  min-height: 2px;
+  border-radius: 4px 4px 0 0;
+  transition: height 0.3s ease;
+}
+
+.weekly-report__day {
+  font-size: 11px;
+  color: #636366;
+  font-weight: 500;
+}
+
+.weekly-report__day.today {
+  color: #30d158;
+  font-weight: 700;
+}
+
+/* ── Trend Chart ── */
+
+.trend-section {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.trend-chart {
+  background: rgba(255,255,255,0.03);
+  border: 1px solid rgba(255,255,255,0.07);
+  border-radius: 12px;
+  padding: 16px 20px;
+}
+
+.trend-chart__header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+
+.trend-chart__title {
+  font-size: 13px;
+  font-weight: 600;
+  color: #ebebf5cc;
+}
+
+.trend-chart__avg {
+  font-size: 12px;
+  color: #0a84ff;
+  font-weight: 600;
+}
+
+.trend-chart__svg {
+  display: block;
+  border-radius: 6px;
+}
+
+/* ── Habit Insights ── */
+
+.habit-insights {
+  background: rgba(255,255,255,0.03);
+  border: 1px solid rgba(255,255,255,0.07);
+  border-radius: 12px;
+  padding: 16px 20px;
+}
+
+.habit-insights__title {
+  font-size: 13px;
+  font-weight: 600;
+  color: #8e8e93;
+  margin: 0 0 14px;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.habit-insights__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+  gap: 10px;
+  margin-bottom: 14px;
+}
+
+.habit-card {
+  background: rgba(255,255,255,0.05);
+  border: 1px solid rgba(255,255,255,0.08);
+  border-radius: 10px;
+  padding: 12px;
+  text-align: center;
+}
+
+.habit-card__value {
+  font-size: 22px;
+  font-weight: 700;
+  color: #fff;
+  line-height: 1.1;
+}
+
+.habit-card__label {
+  font-size: 11px;
+  color: #8e8e93;
+  margin-top: 4px;
+  line-height: 1.3;
+}
+
+.habit-card__sub {
+  font-size: 10px;
+  color: #48484a;
+  margin-top: 2px;
+}
+
+.habit-insights__best {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 12px;
+  background: rgba(10,132,255,0.1);
+  border: 1px solid rgba(10,132,255,0.2);
+  border-radius: 8px;
+}
+
+.habit-insights__best-label {
+  font-size: 11px;
+  color: #8e8e93;
+  flex-shrink: 0;
+}
+
+.habit-insights__best-date {
+  font-size: 12px;
+  color: #ebebf5cc;
+  flex: 1;
+}
+
+.habit-insights__best-pct {
+  font-size: 14px;
+  font-weight: 700;
+  color: #0a84ff;
+}
+
+/* ── Saved References 검색/태그 필터 ── */
+
+.saved-refs__filters {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-bottom: 12px;
+}
+
+.saved-refs__search {
+  width: 100%;
+  background: rgba(255,255,255,0.07);
+  border: 1px solid rgba(255,255,255,0.1);
+  border-radius: 9px;
+  color: #ebebf5;
+  font-size: 13px;
+  padding: 8px 12px;
+  box-sizing: border-box;
+  color-scheme: dark;
+  transition: border-color 0.15s;
+}
+
+.saved-refs__search:focus {
+  outline: none;
+  border-color: #0a84ff;
+}
+
+.saved-refs__search::placeholder {
+  color: #48484a;
+}
+
+.saved-refs__tags {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.saved-ref-tag--filter {
+  background: rgba(255,255,255,0.06);
+  border: 1px solid rgba(255,255,255,0.1);
+  border-radius: 20px;
+  padding: 3px 10px;
+  font-size: 11px;
+  color: #8e8e93;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.saved-ref-tag--filter:hover {
+  background: rgba(255,255,255,0.1);
+  color: #ebebf5;
+}
+
+.saved-ref-tag--filter.active {
+  background: rgba(10,132,255,0.18);
+  border-color: #0a84ff;
+  color: #0a84ff;
+}

--- a/src/components/Dashboard/ExportButton.tsx
+++ b/src/components/Dashboard/ExportButton.tsx
@@ -1,0 +1,121 @@
+import { useState } from "react";
+import { exportData, type ExportFormat } from "../../services/export";
+import { openPath } from "@tauri-apps/plugin-opener";
+
+function todayStr(): string {
+  return new Date().toISOString().split("T")[0];
+}
+
+function thirtyDaysAgoStr(): string {
+  const d = new Date();
+  d.setDate(d.getDate() - 30);
+  return d.toISOString().split("T")[0];
+}
+
+export function ExportButton() {
+  const [open, setOpen] = useState(false);
+  const [startDate, setStartDate] = useState(thirtyDaysAgoStr);
+  const [endDate, setEndDate] = useState(todayStr);
+  const [format, setFormat] = useState<ExportFormat>("csv");
+  const [status, setStatus] = useState<"idle" | "loading" | "success" | "error">("idle");
+  const [savedPath, setSavedPath] = useState("");
+  const [errorMsg, setErrorMsg] = useState("");
+
+  async function handleExport() {
+    setStatus("loading");
+    setErrorMsg("");
+    try {
+      const path = await exportData(startDate, endDate, format);
+      setSavedPath(path);
+      setStatus("success");
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : String(e);
+      setErrorMsg(msg);
+      setStatus("error");
+    }
+  }
+
+  function handleReveal() {
+    // Open the folder containing the file
+    const dir = savedPath.substring(0, savedPath.lastIndexOf("/"));
+    openPath(dir).catch(() => openPath(savedPath));
+  }
+
+  if (!open) {
+    return (
+      <button className="export-trigger" onClick={() => { setOpen(true); setStatus("idle"); }}>
+        ↓ 내보내기
+      </button>
+    );
+  }
+
+  return (
+    <div className="export-panel">
+      <div className="export-panel__header">
+        <span className="export-panel__title">데이터 내보내기</span>
+        <button className="export-panel__close" onClick={() => { setOpen(false); setStatus("idle"); }}>
+          ✕
+        </button>
+      </div>
+
+      <div className="export-panel__row">
+        <label className="export-panel__label">시작일</label>
+        <input
+          type="date"
+          className="export-panel__input"
+          value={startDate}
+          max={endDate}
+          onChange={(e) => setStartDate(e.target.value)}
+        />
+      </div>
+
+      <div className="export-panel__row">
+        <label className="export-panel__label">종료일</label>
+        <input
+          type="date"
+          className="export-panel__input"
+          value={endDate}
+          min={startDate}
+          max={todayStr()}
+          onChange={(e) => setEndDate(e.target.value)}
+        />
+      </div>
+
+      <div className="export-panel__row">
+        <label className="export-panel__label">형식</label>
+        <div className="export-panel__formats">
+          {(["csv", "json"] as ExportFormat[]).map((f) => (
+            <button
+              key={f}
+              className={`export-format-btn${format === f ? " export-format-btn--active" : ""}`}
+              onClick={() => setFormat(f)}
+            >
+              {f.toUpperCase()}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {status === "success" && (
+        <div className="export-panel__success">
+          <span>저장 완료</span>
+          <button className="export-panel__reveal" onClick={handleReveal}>
+            폴더 열기
+          </button>
+        </div>
+      )}
+
+      {status === "error" && (
+        <p className="export-panel__error">{errorMsg}</p>
+      )}
+
+      <button
+        className="export-panel__btn"
+        onClick={handleExport}
+        disabled={status === "loading"}
+      >
+        {status === "loading" ? "내보내는 중…" : "내보내기"}
+      </button>
+    </div>
+  );
+}

--- a/src/components/Dashboard/WeeklyReport.tsx
+++ b/src/components/Dashboard/WeeklyReport.tsx
@@ -24,14 +24,18 @@ interface Props {
 
 export function WeeklyReport({ weekOffset = 0 }: Props) {
   const [stats, setStats] = useState<WeeklyDayStat[]>([]);
-  const [startDate, setStartDate] = useState("");
+  const [startDate, setStartDate] = useState(() => {
+    const base = new Date();
+    base.setDate(base.getDate() + weekOffset * 7);
+    return getMonday(base);
+  });
 
   useEffect(() => {
     const base = new Date();
     base.setDate(base.getDate() + weekOffset * 7);
     const monday = getMonday(base);
     setStartDate(monday);
-    getWeeklyReport(monday).then(setStats);
+    getWeeklyReport(monday).then(setStats).catch(() => setStats([]));
   }, [weekOffset]);
 
   // 7일 슬롯 생성 (데이터 없는 날은 0으로)

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,4 +1,5 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, Component } from "react";
+import type { ReactNode } from "react";
 import type { Activity, DomainSummary, FocusMetrics, Reference, SessionEvent } from "../types/bindings";
 import { getActivityTimeline, getTopSites, getDailyFocusStats, getSessionEvents } from "../services/activity";
 import { getReferences } from "../services/reference";
@@ -10,6 +11,7 @@ import { DatePicker } from "../components/Dashboard/DatePicker";
 import { WeeklyReport } from "../components/Dashboard/WeeklyReport";
 import { TrendChart } from "../components/Dashboard/TrendChart";
 import { HabitInsights } from "../components/Dashboard/HabitInsights";
+import { ExportButton } from "../components/Dashboard/ExportButton";
 
 function todayDateStr(): string {
   return new Date().toISOString().split("T")[0];
@@ -22,6 +24,29 @@ function shiftDate(dateStr: string, days: number): string {
 }
 
 type Tab = "timeline" | "sites" | "score" | "refs" | "weekly" | "trend";
+
+class TabErrorBoundary extends Component<{ children: ReactNode }, { error: Error | null }> {
+  constructor(props: { children: ReactNode }) {
+    super(props);
+    this.state = { error: null };
+  }
+  static getDerivedStateFromError(error: Error) {
+    return { error };
+  }
+  render() {
+    if (this.state.error) {
+      return (
+        <div className="dash-error">
+          <p>이 탭을 불러오는 중 오류가 발생했습니다.</p>
+          <button className="dash-tab" onClick={() => this.setState({ error: null })}>
+            다시 시도
+          </button>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}
 
 export function Dashboard() {
   const [date, setDate] = useState(todayDateStr);
@@ -73,6 +98,9 @@ export function Dashboard() {
     <div className="dashboard">
       <div className="dash-header">
         <h1 className="dash-title">Dashboard</h1>
+        <div className="dash-header-actions">
+          <ExportButton />
+        </div>
         {isDayTab && (
           <div className="dash-date-nav">
             <button
@@ -108,39 +136,41 @@ export function Dashboard() {
       </div>
 
       <div className="dash-content">
-        {loading && isDayTab ? (
-          <p className="dash-loading">로딩 중...</p>
-        ) : (
-          <>
-            {tab === "timeline" && <ActivityTimeline activities={activities} sessionEvents={sessionEvents} />}
-            {tab === "sites" && <TopSites sites={sites} />}
-            {tab === "score" && <FocusScore metrics={metrics} />}
-            {tab === "weekly" && (
-              <div className="weekly-section">
-                <div className="weekly-section__block">
-                  <h3 className="weekly-section__subtitle">이번 주</h3>
-                  <WeeklyReport weekOffset={0} />
+        <TabErrorBoundary key={tab}>
+          {loading && isDayTab ? (
+            <p className="dash-loading">로딩 중...</p>
+          ) : (
+            <>
+              {tab === "timeline" && <ActivityTimeline activities={activities} sessionEvents={sessionEvents} />}
+              {tab === "sites" && <TopSites sites={sites} />}
+              {tab === "score" && <FocusScore metrics={metrics} />}
+              {tab === "weekly" && (
+                <div className="weekly-section">
+                  <div className="weekly-section__block">
+                    <h3 className="weekly-section__subtitle">이번 주</h3>
+                    <WeeklyReport weekOffset={0} />
+                  </div>
+                  <div className="weekly-section__block">
+                    <h3 className="weekly-section__subtitle">지난 주</h3>
+                    <WeeklyReport weekOffset={-1} />
+                  </div>
                 </div>
-                <div className="weekly-section__block">
-                  <h3 className="weekly-section__subtitle">지난 주</h3>
-                  <WeeklyReport weekOffset={-1} />
+              )}
+              {tab === "trend" && (
+                <div className="trend-section">
+                  <TrendChart />
+                  <HabitInsights />
                 </div>
-              </div>
-            )}
-            {tab === "trend" && (
-              <div className="trend-section">
-                <TrendChart />
-                <HabitInsights />
-              </div>
-            )}
-            {tab === "refs" && (
-              <SavedReferences
-                references={refs}
-                onRefresh={() => getReferences().then(setRefs)}
-              />
-            )}
-          </>
-        )}
+              )}
+              {tab === "refs" && (
+                <SavedReferences
+                  references={refs}
+                  onRefresh={() => getReferences().then(setRefs)}
+                />
+              )}
+            </>
+          )}
+        </TabErrorBoundary>
       </div>
     </div>
   );

--- a/src/services/export.ts
+++ b/src/services/export.ts
@@ -1,0 +1,11 @@
+import { invoke } from "@tauri-apps/api/core";
+
+export type ExportFormat = "csv" | "json";
+
+export async function exportData(
+  startDate: string,
+  endDate: string,
+  format: ExportFormat,
+): Promise<string> {
+  return invoke<string>("export_data", { startDate, endDate, format });
+}


### PR DESCRIPTION
## Summary

- **Bug Fix**: `WeeklyReport` 탭 클릭 시 `new Date("").toISOString()` → `RangeError`로 흰화면이 되던 버그 수정 (lazy initializer 적용)
- **Bug Fix**: `Dashboard`에 `TabErrorBoundary` 추가 — 탭 단위 에러가 전체 앱 네비게이션을 죽이지 않도록 방어
- **Feature**: `export_data` Rust 커맨드 — 날짜 범위 + CSV/JSON 형식으로 Downloads 폴더 저장
- **Feature**: `ExportButton` 컴포넌트 — 날짜 범위 선택, 형식 선택, 저장 후 폴더 열기
- **UI**: `titleBarStyle: "overlay"` + `hiddenTitle: true` — dashboard/settings/save-reference/onboarding 창의 네이티브 타이틀바 제거, 트래픽라이트 영역만 남김
- **UI**: WeeklyReport, TrendChart, HabitInsights, SavedReferences 검색/태그 필터 전면 스타일링 (현재 다크 테마 적용)

## Test plan

- [ ] Dashboard 탭 전환 (timeline/sites/score/weekly/trend/refs) — 흰화면 없이 정상 전환 확인
- [ ] 주간/트렌드 탭 정상 렌더링 확인
- [ ] Dashboard 헤더 `↓ 내보내기` 버튼 클릭 → 패널 열림
- [ ] 날짜 범위 선택 후 CSV/JSON 내보내기 → Downloads에 파일 저장 확인
- [ ] Dashboard/Settings 창 열기 — 타이틀바 없이 트래픽라이트만 표시 확인
- [ ] 창 드래그 이동 동작 확인 (dash-header 드래그 영역)

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)