### PR TITLE
[#32] Phase F: 타이틀 규칙 설정 UI

### DIFF
--- a/.vite/deps/_metadata.json
+++ b/.vite/deps/_metadata.json
@@ -1,0 +1,8 @@
+{
+  "hash": "3505d352",
+  "configHash": "d36bb94e",
+  "lockfileHash": "7653187a",
+  "browserHash": "9db0a0b5",
+  "optimized": {},
+  "chunks": {}
+}

--- a/.vite/deps/package.json
+++ b/.vite/deps/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@tauri-apps/api": "^2",
+        "@tauri-apps/plugin-autostart": "^2.5.1",
         "@tauri-apps/plugin-opener": "^2.5.3",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -1545,6 +1546,15 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-autostart": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-autostart/-/plugin-autostart-2.5.1.tgz",
+      "integrity": "sha512-zS/xx7yzveCcotkA+8TqkI2lysmG2wvQXv2HGAVExITmnFfHAdj1arGsbbfs3o6EktRHf6l34pJxc3YGG2mg7w==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.8.0"
       }
     },
     "node_modules/@tauri-apps/plugin-opener": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@tauri-apps/api": "^2",
+        "@tauri-apps/plugin-opener": "^2.5.3",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "zustand": "^5"
@@ -1544,6 +1545,15 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-opener": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-opener/-/plugin-opener-2.5.3.tgz",
+      "integrity": "sha512-CCcUltXMOfUEArbf3db3kCE7Ggy1ExBEBl51Ko2ODJ6GDYHRp1nSNlQm5uNCFY5k7/ufaK5Ib3Du/Zir19IYQQ==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.8.0"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@tauri-apps/api": "^2",
+    "@tauri-apps/plugin-autostart": "^2.5.1",
     "@tauri-apps/plugin-opener": "^2.5.3",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/package.json
+++ b/package.json
@@ -12,23 +12,24 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@tauri-apps/api": "^2",
+    "@tauri-apps/plugin-opener": "^2.5.3",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "@tauri-apps/api": "^2",
     "zustand": "^5"
   },
   "devDependencies": {
+    "@tauri-apps/cli": "^2",
+    "@testing-library/jest-dom": "^6",
+    "@testing-library/react": "^16",
+    "@testing-library/user-event": "^14",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react": "^4.6.0",
+    "@vitest/ui": "^3",
+    "jsdom": "^26",
     "typescript": "~5.8.3",
     "vite": "^7.0.4",
-    "@tauri-apps/cli": "^2",
-    "vitest": "^3",
-    "@vitest/ui": "^3",
-    "@testing-library/react": "^16",
-    "@testing-library/user-event": "^14",
-    "@testing-library/jest-dom": "^6",
-    "jsdom": "^26"
+    "vitest": "^3"
   }
 }

--- a/specs/001-activity-focus-tracker/spec.md
+++ b/specs/001-activity-focus-tracker/spec.md
@@ -214,3 +214,155 @@
 - 세션은 동시에 하나만 실행된다(다중 세션 미지원).
 - 브라우저 외 일반 앱(Xcode, Figma 등)은 url/domain 없이 app_name만 기록하며 Neutral로 분류된다.
 - 로우 Activity 데이터 기본 보관 기간은 30일이며, 사용자가 변경할 수 있다. 기간 초과 시 일별 집계(ArchivedDailySummary)로 자동 변환된다.
+
+---
+
+## 로드맵 — Phase A~D (v2 확장)
+
+> 핵심 기능(US1~US6) 완료 후 단계적으로 추가되는 기능들.
+
+---
+
+### Phase A — 온보딩 + 설정 완성
+
+#### A1. 온보딩 (첫 실행 설정)
+
+첫 실행 시 별도 온보딩 창이 표시된다.
+
+**플로우:**
+1. **Welcome 화면**: 앱 간략 소개 (추적 → 분류 → 분석 흐름 설명)
+2. **직업 선택**: 개발자 / 디자이너 / 마케터 / 기타 / 스킵
+3. **규칙 미리보기 + 완료**: 선택한 직업 기반 규칙 확인 후 시작
+
+**직업별 기본 규칙 추가 (app_name 기반):**
+
+| 직업 | Focus 추가 |
+|------|-----------|
+| 개발자 | iTerm2, Xcode, VS Code, IntelliJ IDEA, Terminal, Slack, Linear |
+| 디자이너 | Figma, Sketch, Adobe XD, Zeplin, Abstract |
+| 마케터 | Notion, HubSpot, Mailchimp |
+| 스킵/기타 | (기존 도메인 기본값만 유지) |
+
+**완료 감지**: `settings` 테이블의 `onboarding_completed` 키. 없으면 온보딩 창 표시.
+
+---
+
+#### A2. 로그인 시 자동 실행
+
+- `tauri-plugin-autostart` 사용
+- 설정 창에 토글 추가 (기본값: OFF)
+- ON 시 macOS LaunchAgents에 등록, OFF 시 해제
+
+---
+
+#### A3. 트레이 아이콘 상태 반영
+
+현재 활동 분류에 따라 트레이 아이콘 변경:
+- 세션 없음: 🔵
+- Focus: 🟢
+- Neutral: 🟡
+- Distraction: 🔴
+
+---
+
+#### A4. 단축키 확장
+
+세션 시작/종료도 전역 단축키로 등록:
+- 세션 시작: `⌘⇧S` (기본값, 변경 가능)
+- 세션 종료: `⌘⇧E` (기본값, 변경 가능)
+- 설정 창에서 변경 가능
+
+---
+
+#### A5. 실시간 분류 변경 (Quick Override)
+
+Dropdown에서 현재 활동의 분류를 즉시 변경할 수 있다.
+
+**동작:**
+1. 현재 활동 분류 배지 클릭 → Focus / Neutral / Distraction 선택기 표시
+2. 선택 후 옵션 제시:
+   - **"이번만 변경"**: 현재 세션의 해당 activity만 업데이트
+   - **"항상 이렇게"**: 규칙 영구 저장
+
+**제목 기반 규칙 (Title-aware Classification):**
+
+YouTube, Instagram 등 콘텐츠에 따라 분류가 달라지는 사이트는 도메인 규칙 대신 **페이지 제목 키워드** 기반 규칙으로 저장된다.
+
+- 예: youtube.com에서 "React Tutorial" 시청 중 → Focus 선택 → `title_rules`에 (youtube.com, "react tutorial", Focus) 저장
+- 이후 youtube.com에서 "react" 포함 제목 → 자동으로 Focus 분류
+
+**이중 용도 도메인** (youtube.com, instagram.com, reddit.com 등)은 도메인 규칙보다 title_rules가 우선 적용된다.
+
+**분류 우선순위:**
+1. title_rules (domain + title keyword 매칭) — 최우선
+2. classification_rules (domain 매칭)
+3. 내장 기본 규칙
+4. Neutral (기본값)
+
+**DB 변경:** `title_rules` 테이블 신규 추가
+```sql
+CREATE TABLE title_rules (
+    id       INTEGER PRIMARY KEY AUTOINCREMENT,
+    domain   TEXT NOT NULL,
+    keyword  TEXT NOT NULL,  -- 소문자, title contains 매칭
+    category TEXT NOT NULL
+);
+```
+
+---
+
+### Phase B — 목표 + 알림
+
+#### B1. 세션 목표 설정
+
+- Dropdown에서 "오늘 목표" 시간 설정 (1~8시간)
+- 달성률 프로그레스 바 표시
+- 목표 달성 시 macOS 알림
+
+#### B2. Focus Score 알림
+
+- 세션 중 집중도가 설정한 임계값(기본 40%) 이하로 10분 이상 지속 시 macOS 알림
+- 알림 임계값 설정 창에서 변경 가능
+
+---
+
+### Phase C — Dashboard 강화
+
+#### C1. 주간 리포트
+
+- Dashboard에 "주간" 뷰 탭 추가
+- 요일별 Focus 시간 바 차트
+- 이번 주 vs 지난 주 비교
+
+#### C2. 트렌드 차트
+
+- 최근 30일 Focus % 꺾은선 그래프
+- 주간 평균 추이 확인
+
+#### C3. 앱별 습관 분석
+
+- 시간대별, 요일별 앱 사용 패턴 표시
+- "월~화에 Slack 사용 집중" 등 패턴 텍스트 요약
+
+#### C4. Reference 검색
+
+- Dashboard References 탭에 텍스트 검색 입력창
+- 태그 클릭 필터링
+
+---
+
+### Phase D — 내보내기
+
+#### D1. CSV / JSON 내보내기
+
+- Dashboard에 내보내기 버튼
+- 날짜 범위 선택 → 활동 / 세션 / Reference 데이터 내보내기
+- 형식: CSV (스프레드시트 호환), JSON (개발자용)
+
+---
+
+### 보류 — AI 분류 제안
+
+Claude API 연동 방식, 비용, 오프라인 동작 여부 결정 후 별도 진행.
+
+아이디어: 새 도메인 첫 방문 시 "이 도메인을 어떻게 분류할까요?" 또는 제목 분석 기반 자동 제안.

--- a/specs/001-activity-focus-tracker/tasks.md
+++ b/specs/001-activity-focus-tracker/tasks.md
@@ -313,37 +313,20 @@ title_rules (domain+keyword) → domain_rules (domain) → app_rules (app_name) 
 
 ### 백엔드
 
-- [ ] TE001 `src-tauri/migrations/V7__app_rules.sql`: `app_rules` 테이블 생성
-  ```sql
-  CREATE TABLE IF NOT EXISTS app_rules (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    app_name TEXT NOT NULL UNIQUE,
-    category TEXT NOT NULL CHECK (category IN ('Focus', 'Neutral', 'Distraction'))
-  );
-  CREATE INDEX IF NOT EXISTS idx_app_rules_app_name ON app_rules(app_name);
-  ```
-- [ ] TE002 [P] `src-tauri/src/services/classifier.rs` 업데이트: `classify` 함수 시그니처에 `app_rules: &[(String, String)]` 파라미터 추가, 우선순위 적용
-  - `title_rules` → `domain_rules` → `app_rules` → 내장 기본값 → Neutral
-  - TDD: 테스트 먼저 작성 (app_rule 매칭, 우선순위 검증)
-- [ ] TE003 [P] `src-tauri/src/services/activity.rs`: `load_app_rules(pool)` 함수 추가, `poll_once`에서 호출
-- [ ] TE004 [P] `src-tauri/src/commands/activity.rs`: `get_tracked_apps` 커맨드 추가
-  ```sql
-  SELECT DISTINCT app_name FROM activities ORDER BY app_name ASC
-  ```
-- [ ] TE005 [P] `src-tauri/src/commands/settings.rs`: `get_app_rules`, `add_app_rule(app_name, category)`, `delete_app_rule(id)` 커맨드 추가
-- [ ] TE006 `src-tauri/src/lib.rs`: TE005 커맨드 `invoke_handler`에 등록
+- [x] TE001 `src-tauri/migrations/V7__app_rules.sql`: `app_rules` 테이블 생성
+- [x] TE002 [P] `src-tauri/src/services/classifier.rs` 업데이트: `app_name` + `app_rules` 파라미터 추가, domain 없는 네이티브 앱에만 적용 (우선순위: title_rules → domain_rules → 내장 기본값 → app_rules → Neutral)
+- [x] TE003 [P] `src-tauri/src/services/tracker.rs`: `load_app_rules` 추가, `poll_once`에서 호출
+- [x] TE004 [P] `src-tauri/src/commands/activity.rs`: `get_tracked_apps` 커맨드 추가
+- [x] TE005 [P] `src-tauri/src/commands/settings.rs` + `services/settings.rs`: `get_app_rules`, `add_app_rule`, `delete_app_rule` 추가
+- [x] TE006 `src-tauri/src/lib.rs`: 커맨드 등록
 
 ### 프론트엔드
 
-- [ ] TE007 [P] `src/types/bindings.ts`: `AppRule { id: number; app_name: string; category: string }` 인터페이스 추가
-- [ ] TE008 [P] `src/services/settings.ts`: `getAppRules`, `addAppRule`, `deleteAppRule` 추가
-- [ ] TE009 [P] `src/services/activity.ts`: `getTrackedApps(): Promise<string[]>` 추가
-- [ ] TE010 `src/components/Settings/AppRuleSettings.tsx`: 앱 규칙 설정 컴포넌트 구현
-  - **추적된 앱 목록 선택**: `getTrackedApps()`로 조회한 앱 이름 드롭다운 (이미 규칙 있는 항목 비활성화)
-  - **직접 입력**: 텍스트 입력창으로 앱 이름 수동 입력
-  - Focus / Neutral / Distraction 선택 드롭다운
-  - 추가된 규칙 목록 표시 + 삭제 버튼
-- [ ] TE011 `src/pages/Settings.tsx`: `<AppRuleSettings />` 섹션 추가 (도메인 규칙 섹션 아래)
+- [x] TE007 [P] `src/types/bindings.ts`: `AppRule` 인터페이스 추가
+- [x] TE008 [P] `src/services/settings.ts`: `getAppRules`, `addAppRule`, `deleteAppRule` 추가
+- [x] TE009 [P] `src/services/activity.ts`: `getTrackedApps()` 추가
+- [x] TE010 `src/components/Settings/AppRuleSettings.tsx`: 앱 규칙 설정 컴포넌트 구현 (추적앱 드롭다운 + 직접입력, 규칙 목록 + 삭제)
+- [x] TE011 `src/pages/Settings.tsx`: `<AppRuleSettings />` 섹션 추가
 
 ---
 

--- a/specs/001-activity-focus-tracker/tasks.md
+++ b/specs/001-activity-focus-tracker/tasks.md
@@ -155,20 +155,20 @@
 
 ### 테스트 먼저 작성 (Red) ⚠️
 
-- [ ] T051 [P] [US5] `src-tauri/tests/metrics_tests.rs` 추가: `get_activity_timeline`, `get_top_sites` 커맨드 테스트 — 날짜별 필터링, 보관 기간 초과 시 ArchivedDailySummary 반환
-- [ ] T052 [P] [US5] `src/__tests__/components/ActivityTimeline.test.tsx` 작성: `mockIPC()` 사용, 활동 목록 시간순 렌더링, 빈 상태 렌더링 테스트
-- [ ] T053 [P] [US5] `src/__tests__/components/TopSites.test.tsx` 작성: 도메인 사용 시간 내림차순 정렬 렌더링 테스트
+- [x] T051 [P] [US5] `src-tauri/tests/activity_tests.rs` 신규 작성: `query_activity_timeline`, `query_top_sites`, `query_daily_focus_stats` 서비스 테스트 12개 (날짜별 필터링, 도메인 집계, 정렬, limit 적용)
+- [x] T052 [P] [US5] `src/__tests__/components/Dashboard/ActivityTimeline.test.tsx` 작성: 활동 목록 렌더링, 빈 상태, 도메인 표시, timeline-dot, duration 포맷 테스트 (5개)
+- [x] T053 [P] [US5] `src/__tests__/components/Dashboard/TopSites.test.tsx` 작성: 도메인 목록, 빈 상태, 시간 포맷, site-dot, site-bar 테스트 (5개)
 
 ### 구현 (Green)
 
-- [ ] T054 [P] [US5] `src-tauri/src/services/archive.rs` 구현: `archive_old_data(db, retention_days)` — 보관 기간 초과 날짜의 Activity를 `ArchivedDailySummary`로 집계 후 원본 삭제
-- [ ] T055 [P] [US5] `src-tauri/src/commands/activity.rs` 업데이트: `get_activity_timeline(date: String)`, `get_top_sites(date: String, limit: u32)` 커맨드 추가 — 보관 기간 내외 분기 처리
-- [ ] T056 [P] [US5] `src/components/Dashboard/ActivityTimeline.tsx` 구현: 활동 목록 시간순 표시, Classification별 색상 구분
-- [ ] T057 [P] [US5] `src/components/Dashboard/TopSites.tsx` 구현: 도메인별 누적 시간 바 차트 (사용 시간 기준 정렬)
-- [ ] T058 [P] [US5] `src/components/Dashboard/FocusScore.tsx` 구현: Focus % 요약 표시, 날짜 필터 컨트롤
-- [ ] T059 [P] [US5] `src/components/Dashboard/SavedReferences.tsx` 구현: `Reference[]` 목록 표시, URL 클릭 시 브라우저 열기
-- [ ] T060 [US5] `src/pages/Dashboard.tsx` 작성: 모든 Dashboard 컴포넌트 통합, 날짜 필터 상태 관리 (T056~T059 의존)
-- [ ] T061 [US5] Dashboard 창 열기 연결: `src-tauri/src/commands/session.rs`에 `open_dashboard` 커맨드 추가, `src/components/Dropdown/SessionControls.tsx`에 "Dashboard 열기" 버튼 추가
+- [x] T054 [P] [US5] `src-tauri/src/services/archive.rs` 구현: `archive_old_data(pool, retention_days)` — 보관 기간 초과 날짜 Activity를 ArchivedDailySummary로 집계 후 원본 삭제
+- [x] T055 [P] [US5] `src-tauri/src/services/activity.rs` + `commands/activity.rs` 신규: `get_activity_timeline`, `get_top_sites`, `get_daily_focus_stats` 커맨드 + `open_url` 추가
+- [x] T056 [P] [US5] `src/components/Dashboard/ActivityTimeline.tsx` 구현: 활동 목록 시간순, Classification 색상 dot, duration/domain 표시
+- [x] T057 [P] [US5] `src/components/Dashboard/TopSites.tsx` 구현: 도메인별 바 차트 (최장 기준 비율), 색상 구분
+- [x] T058 [P] [US5] `src/components/Dashboard/FocusScore.tsx` 구현: Focus % 큰 숫자 + 3개 카테고리 바 + 총 시간
+- [x] T059 [P] [US5] `src/components/Dashboard/SavedReferences.tsx` 구현: Reference 목록, URL 클릭 시 `open_url` 커맨드로 브라우저 열기
+- [x] T060 [US5] `src/pages/Dashboard.tsx` 완전 재구현: 탭(타임라인/TopSites/FocusScore/References) + 날짜 필터 + 데이터 로드
+- [x] T061 [US5] `open_dashboard` 커맨드 기존 구현 확인 (T031에서 완료), `src/services/activity.ts` 신규 invoke 래퍼 추가
 
 **체크포인트**: `cargo test`, `npm test` 통과, Dashboard 열리고 날짜 필터 동작 확인
 

--- a/specs/001-activity-focus-tracker/tasks.md
+++ b/specs/001-activity-focus-tracker/tasks.md
@@ -330,6 +330,91 @@ title_rules (domain+keyword) → domain_rules (domain) → app_rules (app_name) 
 
 ---
 
+## Phase F: 타이틀 규칙 설정 UI (Issue #32)
+
+**목표**: `title_rules` 테이블이 DB에 존재하지만 설정 UI가 없어 Quick Override로만 추가 가능. 설정 페이지에서 직접 관리(조회/삭제)할 수 있도록 구현.
+
+### 백엔드
+
+- [ ] TF001 [P] `src-tauri/src/commands/settings.rs` + `services/settings.rs`: `get_title_rules`, `delete_title_rule` 커맨드 추가
+- [ ] TF002 `src-tauri/src/lib.rs`: 커맨드 등록
+
+### 프론트엔드
+
+- [ ] TF003 [P] `src/types/bindings.ts`: `TitleRule` 인터페이스 추가 (`id`, `domain`, `keyword`, `category`)
+- [ ] TF004 [P] `src/services/settings.ts`: `getTitleRules`, `deleteTitleRule` 추가
+- [ ] TF005 `src/components/Settings/TitleRuleSettings.tsx`: 타이틀 규칙 목록(도메인+키워드+분류) + 삭제 버튼
+- [ ] TF006 `src/pages/Settings.tsx`: `<TitleRuleSettings />` 섹션 추가
+
+---
+
+## Phase G: 시간대별 히트맵 및 요일 패턴 시각화 (Issue #33)
+
+**목표**: 대시보드에 시간대별·요일별 집중도 패턴을 시각화하여 언제 가장 집중하는지 파악 가능하게 함.
+
+### 백엔드
+
+- [ ] TG001 `src-tauri/src/commands/activity.rs`: `get_hourly_heatmap(days: u32)` 커맨드 — 시간(0~23) × 요일(0~6) 별 평균 Focus % 반환
+- [ ] TG002 `src-tauri/src/commands/activity.rs`: `get_weekday_stats(days: u32)` 커맨드 — 요일별 평균 Focus 시간(분) 반환
+- [ ] TG003 `src-tauri/src/lib.rs`: 커맨드 등록
+
+### 프론트엔드
+
+- [ ] TG004 [P] `src/types/bindings.ts`: `HeatmapCell` (`hour`, `weekday`, `focus_pct`), `WeekdayStat` (`weekday`, `avg_focus_mins`) 인터페이스 추가
+- [ ] TG005 [P] `src/services/activity.ts`: `getHourlyHeatmap`, `getWeekdayStats` 추가
+- [ ] TG006 `src/components/Dashboard/PatternView.tsx`: 히트맵 그리드(24×7) + 요일별 바 차트 구현
+- [ ] TG007 `src/pages/Dashboard.tsx`: `패턴` 탭 추가 및 `PatternView` 연결
+
+---
+
+## Phase H: 세션 목표 달성 히스토리 (Issue #34)
+
+**목표**: 매일 목표 달성 여부를 기록하고 대시보드에서 스트릭 및 달성 캘린더를 확인할 수 있도록 함.
+
+### 백엔드
+
+- [ ] TH001 `src-tauri/migrations/V8__goal_history.sql`: `goal_history` 테이블 생성 (`date TEXT PK`, `target_secs INT`, `actual_secs INT`, `achieved BOOL`)
+- [ ] TH002 `src-tauri/src/services/goal.rs`: `record_daily_goal_result(date, target_secs, actual_secs)` 함수 추가
+- [ ] TH003 `src-tauri/src/commands/session.rs`: 세션 종료 시 `record_daily_goal_result` 호출
+- [ ] TH004 [P] `src-tauri/src/commands/activity.rs`: `get_goal_history(days: u32)` 커맨드 — 날짜별 달성 여부 목록 반환
+- [ ] TH005 `src-tauri/src/lib.rs`: 커맨드 등록
+
+### 프론트엔드
+
+- [ ] TH006 [P] `src/types/bindings.ts`: `GoalHistoryEntry` (`date`, `target_secs`, `actual_secs`, `achieved`) 인터페이스 추가
+- [ ] TH007 [P] `src/services/activity.ts`: `getGoalHistory(days)` 추가
+- [ ] TH008 `src/components/Dashboard/GoalHistory.tsx`: 최근 30일 달성 캘린더 + 연속 달성 스트릭 표시
+- [ ] TH009 `src/pages/Dashboard.tsx`: Focus Score 탭에 `GoalHistory` 컴포넌트 추가
+- [ ] TH010 `src/components/Dropdown/GoalProgress.tsx`: 연속 달성 일수 표시 추가
+
+---
+
+## Phase I: UI 폴리싱 및 안정성 개선 (Issue #35)
+
+**목표**: 전반적인 UI 완성도 향상 및 알려진 UX 이슈 수정.
+
+### 대시보드
+
+- [ ] TI001 `src/pages/Dashboard.tsx` + `src/App.css`: 탭 콘텐츠 로딩 시 스켈레톤 UI (현재 빈 화면)
+- [ ] TI002 각 탭 컴포넌트: 데이터 없을 때 통일된 빈 상태 메시지 및 아이콘
+- [ ] TI003 `src/pages/Dashboard.tsx`: 날짜 네비게이션 키보드 단축키 (← →)
+
+### 드롭다운
+
+- [ ] TI004 `src/pages/Dropdown.tsx` + `src/App.css`: 세션 없을 때 오늘 누적 집중 시간 간략 표시
+
+### 설정
+
+- [ ] TI005 `src/pages/Settings.tsx` + `src/App.css`: 저장 성공/실패 토스트 알림 컴포넌트
+- [ ] TI006 `src/pages/Settings.tsx`: 도메인/앱 규칙 추가 시 중복 체크 및 에러 피드백
+
+### 성능
+
+- [ ] TI007 `src/pages/Dashboard.tsx`: 같은 탭 재클릭 시 리페치 방지 (이미 로딩 중이면 skip)
+- [ ] TI008 `src/components/Settings/*.tsx`: 설정 창 데이터 마운트 시 1회만 로드, 불필요한 재요청 제거
+
+---
+
 ## 의존성 및 실행 순서
 
 ### Phase 의존성

--- a/specs/001-activity-focus-tracker/tasks.md
+++ b/specs/001-activity-focus-tracker/tasks.md
@@ -336,15 +336,15 @@ title_rules (domain+keyword) → domain_rules (domain) → app_rules (app_name) 
 
 ### 백엔드
 
-- [ ] TF001 [P] `src-tauri/src/commands/settings.rs` + `services/settings.rs`: `get_title_rules`, `delete_title_rule` 커맨드 추가
-- [ ] TF002 `src-tauri/src/lib.rs`: 커맨드 등록
+- [x] TF001 [P] `src-tauri/src/commands/settings.rs` + `services/settings.rs`: `get_title_rules`, `delete_title_rule` 커맨드 추가
+- [x] TF002 `src-tauri/src/lib.rs`: 커맨드 등록
 
 ### 프론트엔드
 
-- [ ] TF003 [P] `src/types/bindings.ts`: `TitleRule` 인터페이스 추가 (`id`, `domain`, `keyword`, `category`)
-- [ ] TF004 [P] `src/services/settings.ts`: `getTitleRules`, `deleteTitleRule` 추가
-- [ ] TF005 `src/components/Settings/TitleRuleSettings.tsx`: 타이틀 규칙 목록(도메인+키워드+분류) + 삭제 버튼
-- [ ] TF006 `src/pages/Settings.tsx`: `<TitleRuleSettings />` 섹션 추가
+- [x] TF003 [P] `src/types/bindings.ts`: `TitleRule` 인터페이스 추가 (`id`, `domain`, `keyword`, `category`)
+- [x] TF004 [P] `src/services/settings.ts`: `getTitleRules`, `deleteTitleRule` 추가
+- [x] TF005 `src/components/Settings/TitleRuleSettings.tsx`: 타이틀 규칙 목록(도메인+키워드+분류) + 삭제 버튼
+- [x] TF006 `src/pages/Settings.tsx`: `<TitleRuleSettings />` 섹션 추가
 
 ---
 

--- a/specs/001-activity-focus-tracker/tasks.md
+++ b/specs/001-activity-focus-tracker/tasks.md
@@ -296,9 +296,9 @@ Phase 1~10 전체 구현 완료 (2026-03-21). 이하는 v2 확장 Phase.
 
 **목표**: 데이터 주권 + 외부 활용
 
-- [ ] TD001 [P] `src-tauri/src/commands/export.rs`: `export_data(start_date, end_date, format)` — CSV/JSON 생성 후 파일 저장 다이얼로그
-- [ ] TD002 [P] `src/components/Dashboard/ExportButton.tsx`: 날짜 범위 선택 + 형식 선택 (CSV/JSON) + 내보내기 버튼
-- [ ] TD003 `src/pages/Dashboard.tsx` 업데이트: ExportButton 추가
+- [x] TD001 [P] `src-tauri/src/commands/export.rs`: `export_data(start_date, end_date, format)` — CSV/JSON 생성 후 Downloads 폴더 저장 + opener로 폴더 열기
+- [x] TD002 [P] `src/components/Dashboard/ExportButton.tsx`: 날짜 범위 선택 + 형식 선택 (CSV/JSON) + 내보내기 버튼
+- [x] TD003 `src/pages/Dashboard.tsx` 업데이트: ExportButton 추가
 
 ---
 

--- a/specs/001-activity-focus-tracker/tasks.md
+++ b/specs/001-activity-focus-tracker/tasks.md
@@ -181,25 +181,25 @@
 
 ### 테스트 먼저 작성 (Red) ⚠️
 
-- [ ] T062a [P] [US6] `src-tauri/src/commands/settings.rs` 신규 테스트: `get_settings`, `update_settings`, `get_classification_rules`, `add_classification_rule`, `delete_classification_rule` — 단위 테스트 5개
-- [ ] T062b [P] [US6] `src/__tests__/pages/Settings.test.tsx` 작성: 단축키 변경, 보관 기간 선택, 규칙 추가/삭제 렌더링 테스트 (mockIPC)
-- [ ] T062c [P] [US6] `src/__tests__/pages/SaveReference.test.tsx` 작성 (팝업 창 버전): 폼 렌더링, URL 자동채움, 제목 없이 저장 불가, 저장 후 창 닫힘 테스트
+- [x] T062a [P] [US6] `src-tauri/src/commands/settings.rs` 신규 테스트: `get_settings`, `update_settings`, `get_classification_rules`, `add_classification_rule`, `delete_classification_rule` — 단위 테스트 5개
+- [x] T062b [P] [US6] `src/__tests__/pages/Settings.test.tsx` 작성: 단축키 변경, 보관 기간 선택, 규칙 추가/삭제 렌더링 테스트 (mockIPC)
+- [x] T062c [P] [US6] `src/__tests__/pages/SaveReference.test.tsx` 작성 (팝업 창 버전): 폼 렌더링, URL 자동채움, 제목 없이 저장 불가, 저장 후 창 닫힘 테스트
 
 ### 구현 (Green)
 
-- [ ] T063 [US6] `src-tauri/migrations/V3__shortcut.sql` 작성: `settings` 테이블에 `shortcut_save_ref TEXT DEFAULT 'CmdOrCtrl+Shift+R'` 컬럼 추가 (마이그레이션)
-- [ ] T064 [P] [US6] `src-tauri/src/commands/settings.rs` 구현: `get_settings()`, `update_settings(settings)`, `get_classification_rules()`, `add_classification_rule(domain, classification)`, `delete_classification_rule(id)` 커맨드
-- [ ] T065 [P] [US6] `src-tauri/src/services/shortcut.rs` 구현: `register_shortcut(app, shortcut_str)` — `tauri-plugin-global-shortcut`로 `⌘⇧R` 기본 등록, 설정 변경 시 재등록
-- [ ] T066 [P] [US6] `src/services/settings.ts` 작성: `getSettings()`, `updateSettings(settings)`, `getClassificationRules()`, `addClassificationRule(domain, classification)`, `deleteClassificationRule(id)` invoke 래퍼
-- [ ] T067 [P] [US6] `src-tauri/tauri.conf.json` 업데이트: `save-reference` 창 추가 (`width: 480, height: 300, decorations: true, visible: false`), `settings` 창 추가 (`width: 600, height: 500, decorations: true, visible: false`)
-- [ ] T068 [US6] `src-tauri/src/commands/settings.rs`에 `open_save_reference_window`, `open_settings_window` 커맨드 추가; `src-tauri/src/lib.rs`에 트레이 우클릭 메뉴 "설정 열기" 항목 연결
-- [ ] T069 [P] [US6] `src/pages/SaveReference.tsx` 구현 (팝업 창 전용): URL 자동채움 (쿼리 파라미터로 전달), 제목 입력, 태그 입력, 저장 후 창 닫힘 (`getCurrentWindow().close()`)
-- [ ] T070 [P] [US6] `src/components/Settings/ShortcutSettings.tsx` 구현: 현재 단축키 표시, 새 단축키 입력(키 캡처), 저장 시 `updateSettings()` 호출
-- [ ] T071 [P] [US6] `src/components/Settings/RetentionSettings.tsx` 구현: 7일/30일/90일/무제한 라디오 선택, 저장
-- [ ] T072 [P] [US6] `src/components/Settings/RulesSettings.tsx` 구현: 규칙 목록 표시, 도메인+분류 추가 폼, 규칙 삭제 버튼 (즉시 반영)
-- [ ] T073 [P] [US6] `src/components/Settings/AutoLaunchSettings.tsx` 구현: 자동 실행 토글 (macOS `loginItems` API)
-- [ ] T074 [US6] `src/pages/Settings.tsx` 구현: 탭 또는 섹션으로 ShortcutSettings, RetentionSettings, RulesSettings, AutoLaunchSettings 통합
-- [ ] T075 [US6] `src/pages/Dropdown.tsx` 업데이트: "Reference 저장" 버튼 클릭 시 인라인 폼 대신 `openSaveReferenceWindow()` 호출로 변경
+- [x] T063 [US6] `src-tauri/migrations/V3__shortcut.sql` 작성: `settings` 테이블에 `shortcut_save_ref TEXT DEFAULT 'CmdOrCtrl+Shift+R'` 컬럼 추가 (마이그레이션)
+- [x] T064 [P] [US6] `src-tauri/src/commands/settings.rs` 구현: `get_settings()`, `update_settings(settings)`, `get_classification_rules()`, `add_classification_rule(domain, classification)`, `delete_classification_rule(id)` 커맨드
+- [x] T065 [P] [US6] `src-tauri/src/services/shortcut.rs` 구현: `register_shortcut(app, shortcut_str)` — `tauri-plugin-global-shortcut`로 `⌘⇧R` 기본 등록, 설정 변경 시 재등록
+- [x] T066 [P] [US6] `src/services/settings.ts` 작성: `getSettings()`, `updateSettings(settings)`, `getClassificationRules()`, `addClassificationRule(domain, classification)`, `deleteClassificationRule(id)` invoke 래퍼
+- [x] T067 [P] [US6] `src-tauri/tauri.conf.json` 업데이트: `save-reference` 창 추가 (`width: 480, height: 300, decorations: true, visible: false`), `settings` 창 추가 (`width: 600, height: 500, decorations: true, visible: false`)
+- [x] T068 [US6] `src-tauri/src/commands/settings.rs`에 `open_save_reference_window`, `open_settings_window` 커맨드 추가; `src-tauri/src/lib.rs`에 트레이 우클릭 메뉴 "설정 열기" 항목 연결
+- [x] T069 [P] [US6] `src/pages/SaveReference.tsx` 구현 (팝업 창 전용): URL 자동채움 (쿼리 파라미터로 전달), 제목 입력, 태그 입력, 저장 후 창 닫힘 (`getCurrentWindow().close()`)
+- [x] T070 [P] [US6] `src/components/Settings/ShortcutSettings.tsx` 구현: 현재 단축키 표시, 새 단축키 입력(키 캡처), 저장 시 `updateSettings()` 호출
+- [x] T071 [P] [US6] `src/components/Settings/RetentionSettings.tsx` 구현: 7일/30일/90일/무제한 라디오 선택, 저장
+- [x] T072 [P] [US6] `src/components/Settings/RulesSettings.tsx` 구현: 규칙 목록 표시, 도메인+분류 추가 폼, 규칙 삭제 버튼 (즉시 반영)
+- [x] T073 [P] [US6] `src/components/Settings/AutoLaunchSettings.tsx` 구현: 자동 실행 토글 (macOS `loginItems` API)
+- [x] T074 [US6] `src/pages/Settings.tsx` 구현: 탭 또는 섹션으로 ShortcutSettings, RetentionSettings, RulesSettings, AutoLaunchSettings 통합
+- [x] T075 [US6] `src/pages/Dropdown.tsx` 업데이트: "Reference 저장" 버튼 클릭 시 인라인 폼 대신 `openSaveReferenceWindow()` 호출로 변경
 
 **체크포인트**: `cargo test`, `npm test` 통과, `⌘⇧R` 단축키로 팝업 열림, 설정 창에서 규칙 추가 후 분류 즉시 반영
 
@@ -209,8 +209,8 @@
 
 **목표**: 보관 기간 초과 데이터 자동 아카이빙, 앱 시작 시 미완료 세션 처리
 
-- [ ] T076 `src-tauri/src/lib.rs` 업데이트: 앱 시작 시 `archive_old_data()` 호출 (설정된 보관 기간 기준), 이후 `get_incomplete_session()` 확인
-- [ ] T077 `src/pages/Dropdown.tsx` 확인: 앱 초기화 시 `getIncompleteSession()` 호출, 미완료 세션 있으면 "이전 세션을 이어할까요?" 확인 다이얼로그 표시 (이미 T065에서 구현됨)
+- [x] T076 `src-tauri/src/lib.rs` 업데이트: 앱 시작 시 `archive_old_data()` 호출 (설정된 보관 기간 기준), 이후 `get_incomplete_session()` 확인
+- [x] T077 `src/pages/Dropdown.tsx` 확인: 앱 초기화 시 `getIncompleteSession()` 호출, 미완료 세션 있으면 "이전 세션을 이어할까요?" 확인 다이얼로그 표시 (이미 T065에서 구현됨)
 
 ---
 
@@ -218,11 +218,87 @@
 
 **목적**: 권한 오류 처리, 전체 테스트 검증, quickstart.md 기준 검증
 
-- [ ] T078 [P] Accessibility 권한 없을 때 트래커 중단 및 사용자 안내 UI 추가 (`src-tauri/src/services/tracker.rs`, `src/pages/Dropdown.tsx`)
-- [ ] T079 [P] Automation 권한 거부 시 `url = null` 처리 확인 및 에러 로그 추가 (`src-tauri/src/services/browser.rs`)
-- [ ] T080 [P] `cargo test --all` 전체 Rust 테스트 실행 및 미통과 테스트 수정
-- [ ] T081 [P] `npm test` 전체 React 테스트 실행 및 미통과 테스트 수정
-- [ ] T082 `specs/001-activity-focus-tracker/quickstart.md` 검증 체크리스트 기준으로 실제 앱 동작 확인
+- [x] T078 [P] Accessibility 권한 없을 때 트래커 중단 및 사용자 안내 UI 추가 (`src-tauri/src/services/tracker.rs`, `src/pages/Dropdown.tsx`)
+- [x] T079 [P] Automation 권한 거부 시 `url = null` 처리 확인 및 에러 로그 추가 (`src-tauri/src/services/browser.rs`)
+- [x] T080 [P] `cargo test --all` 전체 Rust 테스트 실행 및 미통과 테스트 수정
+- [x] T081 [P] `npm test` 전체 React 테스트 실행 및 미통과 테스트 수정
+- [x] T082 `specs/001-activity-focus-tracker/quickstart.md` 검증 체크리스트 기준으로 실제 앱 동작 확인
+
+---
+
+---
+
+## ✅ 완료된 Phase (Phase 1~10)
+
+Phase 1~10 전체 구현 완료 (2026-03-21). 이하는 v2 확장 Phase.
+
+---
+
+## Phase A: 온보딩 + 설정 완성 + 실시간 분류 변경
+
+**목표**: 첫 실행 경험 개선, 설정 기능 완성, Dropdown에서 즉각적인 분류 수정
+
+**체크포인트**: 온보딩 완료 후 직업 기반 규칙 적용 확인, Quick Override로 분류 변경 시 즉시 반영 및 영구 저장 확인
+
+### 테스트 먼저 작성 (Red)
+
+- [ ] TA001 [P] `src-tauri/src/commands/onboarding.rs` 테스트: `get_onboarding_status`, `complete_onboarding`, `apply_profession_rules` 단위 테스트
+- [ ] TA002 [P] `src-tauri/src/services/classifier.rs` 테스트: title_rules 우선 적용, 이중용도 도메인 title 매칭 테스트
+- [ ] TA003 [P] `src/__tests__/pages/Onboarding.test.tsx`: 직업 선택 렌더링, 스킵 동작, 완료 후 커맨드 호출 테스트
+- [ ] TA004 [P] `src/__tests__/components/Dropdown/QuickOverride.test.tsx`: 분류 배지 클릭 → 선택기 표시, "이번만"/"항상" 동작 테스트
+
+### 구현 (Green)
+
+- [ ] TA005 `src-tauri/migrations/V5__title_rules_onboarding.sql`: `title_rules` 테이블 + `onboarding_completed` 기본 settings 값 추가
+- [ ] TA006 [P] `src-tauri/src/services/classifier.rs` 업데이트: title_rules 조회 및 우선 적용 로직 추가 (domain + title keyword contains 매칭)
+- [ ] TA007 [P] `src-tauri/src/commands/onboarding.rs` 구현: `get_onboarding_status()`, `complete_onboarding(profession)`, `apply_profession_rules(profession)`, `add_title_rule(domain, keyword, category)`, `get_title_rules()`, `delete_title_rule(id)`
+- [ ] TA008 [P] `src-tauri/src/services/settings.rs` 업데이트: title_rules CRUD 서비스 함수 추가
+- [ ] TA009 `src-tauri/tauri.conf.json` 업데이트: `onboarding` 창 추가 (`width: 520, height: 460, decorations: true, visible: false`)
+- [ ] TA010 `src-tauri/src/lib.rs` 업데이트: 앱 시작 시 `onboarding_completed` 확인 → 미완료 시 onboarding 창 표시, 새 커맨드 등록
+- [ ] TA011 [P] `src-tauri/src/commands/session.rs` 업데이트: 세션 시작/종료 전역 단축키 커맨드 추가 (`register_session_shortcuts`)
+- [ ] TA012 [P] `src/pages/Onboarding.tsx` 구현: Step 1(Welcome) → Step 2(직업 선택) → Step 3(규칙 미리보기+완료) 3단계 플로우
+- [ ] TA013 [P] `src/components/Dropdown/QuickOverride.tsx` 구현: 분류 배지 클릭 → Focus/Neutral/Distraction 선택 → "이번만"/"항상 이렇게" 선택, title_rule 또는 domain_rule 저장
+- [ ] TA014 `src/pages/Dropdown.tsx` 업데이트: 현재 활동에 QuickOverride 컴포넌트 연결, 트레이 아이콘 상태 업데이트 로직 연결
+- [ ] TA015 [P] `src/services/onboarding.ts`: `getOnboardingStatus()`, `completeOnboarding(profession)`, `addTitleRule()`, `getTitleRules()`, `deleteTitleRule()` 서비스 레이어
+- [ ] TA016 `src/App.tsx` 업데이트: `onboarding` 창 라우팅 추가
+- [ ] TA017 [P] `src-tauri/src/lib.rs` 트레이 아이콘 갱신: 1초 루프에서 현재 분류 상태에 따라 🔵/🟢/🟡/🔴 업데이트
+- [ ] TA018 [P] `src/components/Settings/AutoLaunchSettings.tsx` 구현 (`tauri-plugin-autostart` 사용), Settings.tsx에 통합
+- [ ] TA019 `src/App.css` 업데이트: 온보딩 스타일, QuickOverride 스타일
+
+---
+
+## Phase B: 목표 + 알림
+
+**목표**: 사용자가 의도를 갖고 세션을 운영할 수 있도록
+
+- [ ] TB001 [P] `src-tauri/migrations/V6__goals.sql`: `session_goals` 테이블 추가 (`target_secs`, `date`)
+- [ ] TB002 [P] `src-tauri/src/commands/goal.rs`: `set_daily_goal(secs)`, `get_daily_goal()`, `get_goal_progress(date)` 커맨드
+- [ ] TB003 [P] `src/components/Dropdown/GoalProgress.tsx`: 목표 시간 설정 + 달성률 프로그레스 바
+- [ ] TB004 [P] `src-tauri/src/services/notification.rs`: `send_notification(title, body)` — macOS 알림 (`tauri-plugin-notification`)
+- [ ] TB005 [P] 세션 루프에 알림 로직 추가: 집중도 임계값(기본 40%) 이하 10분 지속 시 알림, 목표 달성 시 알림
+
+---
+
+## Phase C: Dashboard 강화
+
+**목표**: 데이터 기반 인사이트 제공
+
+- [ ] TC001 [P] `src-tauri/src/services/activity.rs` 추가: `query_weekly_report(start_date)`, `query_trend(days)` 쿼리
+- [ ] TC002 [P] `src/components/Dashboard/WeeklyReport.tsx`: 요일별 Focus 시간 바 차트 (이번 주 vs 지난 주)
+- [ ] TC003 [P] `src/components/Dashboard/TrendChart.tsx`: 최근 30일 Focus % 꺾은선 그래프
+- [ ] TC004 [P] `src/components/Dashboard/HabitInsights.tsx`: 요일/시간대별 패턴 분석 텍스트 요약
+- [ ] TC005 [P] `src/components/Dashboard/SavedReferences.tsx` 업데이트: 검색 입력창 + 태그 클릭 필터
+- [ ] TC006 `src/pages/Dashboard.tsx` 업데이트: 주간/트렌드 탭 추가, 인사이트 섹션 추가
+
+---
+
+## Phase D: 내보내기
+
+**목표**: 데이터 주권 + 외부 활용
+
+- [ ] TD001 [P] `src-tauri/src/commands/export.rs`: `export_data(start_date, end_date, format)` — CSV/JSON 생성 후 파일 저장 다이얼로그
+- [ ] TD002 [P] `src/components/Dashboard/ExportButton.tsx`: 날짜 범위 선택 + 형식 선택 (CSV/JSON) + 내보내기 버튼
+- [ ] TD003 `src/pages/Dashboard.tsx` 업데이트: ExportButton 추가
 
 ---
 

--- a/specs/001-activity-focus-tracker/tasks.md
+++ b/specs/001-activity-focus-tracker/tasks.md
@@ -271,11 +271,11 @@ Phase 1~10 전체 구현 완료 (2026-03-21). 이하는 v2 확장 Phase.
 
 **목표**: 사용자가 의도를 갖고 세션을 운영할 수 있도록
 
-- [ ] TB001 [P] `src-tauri/migrations/V6__goals.sql`: `session_goals` 테이블 추가 (`target_secs`, `date`)
-- [ ] TB002 [P] `src-tauri/src/commands/goal.rs`: `set_daily_goal(secs)`, `get_daily_goal()`, `get_goal_progress(date)` 커맨드
-- [ ] TB003 [P] `src/components/Dropdown/GoalProgress.tsx`: 목표 시간 설정 + 달성률 프로그레스 바
-- [ ] TB004 [P] `src-tauri/src/services/notification.rs`: `send_notification(title, body)` — macOS 알림 (`tauri-plugin-notification`)
-- [ ] TB005 [P] 세션 루프에 알림 로직 추가: 집중도 임계값(기본 40%) 이하 10분 지속 시 알림, 목표 달성 시 알림
+- [X] TB001 [P] `src-tauri/migrations/V6__goals.sql`: `session_goals` 테이블 추가 (`target_secs`, `date`)
+- [X] TB002 [P] `src-tauri/src/commands/goal.rs`: `set_daily_goal(secs)`, `get_daily_goal()`, `get_goal_progress(date)` 커맨드
+- [X] TB003 [P] `src/components/Dropdown/GoalProgress.tsx`: 목표 시간 설정 + 달성률 프로그레스 바
+- [X] TB004 [P] `src-tauri/src/services/notification.rs`: `send_notification(title, body)` — macOS 알림 (`tauri-plugin-notification`)
+- [X] TB005 [P] 세션 루프에 알림 로직 추가: 집중도 임계값(기본 40%) 이하 10분 지속 시 알림, 목표 달성 시 알림
 
 ---
 
@@ -283,12 +283,12 @@ Phase 1~10 전체 구현 완료 (2026-03-21). 이하는 v2 확장 Phase.
 
 **목표**: 데이터 기반 인사이트 제공
 
-- [ ] TC001 [P] `src-tauri/src/services/activity.rs` 추가: `query_weekly_report(start_date)`, `query_trend(days)` 쿼리
-- [ ] TC002 [P] `src/components/Dashboard/WeeklyReport.tsx`: 요일별 Focus 시간 바 차트 (이번 주 vs 지난 주)
-- [ ] TC003 [P] `src/components/Dashboard/TrendChart.tsx`: 최근 30일 Focus % 꺾은선 그래프
-- [ ] TC004 [P] `src/components/Dashboard/HabitInsights.tsx`: 요일/시간대별 패턴 분석 텍스트 요약
-- [ ] TC005 [P] `src/components/Dashboard/SavedReferences.tsx` 업데이트: 검색 입력창 + 태그 클릭 필터
-- [ ] TC006 `src/pages/Dashboard.tsx` 업데이트: 주간/트렌드 탭 추가, 인사이트 섹션 추가
+- [X] TC001 [P] `src-tauri/src/services/activity.rs` 추가: `query_weekly_report(start_date)`, `query_trend(days)` 쿼리
+- [X] TC002 [P] `src/components/Dashboard/WeeklyReport.tsx`: 요일별 Focus 시간 바 차트 (이번 주 vs 지난 주)
+- [X] TC003 [P] `src/components/Dashboard/TrendChart.tsx`: 최근 30일 Focus % 꺾은선 그래프
+- [X] TC004 [P] `src/components/Dashboard/HabitInsights.tsx`: 요일/시간대별 패턴 분석 텍스트 요약
+- [X] TC005 [P] `src/components/Dashboard/SavedReferences.tsx` 업데이트: 검색 입력창 + 태그 클릭 필터
+- [X] TC006 `src/pages/Dashboard.tsx` 업데이트: 주간/트렌드 탭 추가, 인사이트 섹션 추가
 
 ---
 
@@ -299,6 +299,51 @@ Phase 1~10 전체 구현 완료 (2026-03-21). 이하는 v2 확장 Phase.
 - [ ] TD001 [P] `src-tauri/src/commands/export.rs`: `export_data(start_date, end_date, format)` — CSV/JSON 생성 후 파일 저장 다이얼로그
 - [ ] TD002 [P] `src/components/Dashboard/ExportButton.tsx`: 날짜 범위 선택 + 형식 선택 (CSV/JSON) + 내보내기 버튼
 - [ ] TD003 `src/pages/Dashboard.tsx` 업데이트: ExportButton 추가
+
+---
+
+## Phase E: 앱 이름 기반 분류 규칙 (Issue #29)
+
+**목표**: 웹사이트뿐 아니라 네이티브 앱(Xcode, Slack 등)도 Focus/Neutral/Distraction으로 분류 가능하게 함
+
+**분류 우선순위 (변경 후)**:
+```
+title_rules (domain+keyword) → domain_rules (domain) → app_rules (app_name) → 내장 기본값 → Neutral
+```
+
+### 백엔드
+
+- [ ] TE001 `src-tauri/migrations/V7__app_rules.sql`: `app_rules` 테이블 생성
+  ```sql
+  CREATE TABLE IF NOT EXISTS app_rules (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    app_name TEXT NOT NULL UNIQUE,
+    category TEXT NOT NULL CHECK (category IN ('Focus', 'Neutral', 'Distraction'))
+  );
+  CREATE INDEX IF NOT EXISTS idx_app_rules_app_name ON app_rules(app_name);
+  ```
+- [ ] TE002 [P] `src-tauri/src/services/classifier.rs` 업데이트: `classify` 함수 시그니처에 `app_rules: &[(String, String)]` 파라미터 추가, 우선순위 적용
+  - `title_rules` → `domain_rules` → `app_rules` → 내장 기본값 → Neutral
+  - TDD: 테스트 먼저 작성 (app_rule 매칭, 우선순위 검증)
+- [ ] TE003 [P] `src-tauri/src/services/activity.rs`: `load_app_rules(pool)` 함수 추가, `poll_once`에서 호출
+- [ ] TE004 [P] `src-tauri/src/commands/activity.rs`: `get_tracked_apps` 커맨드 추가
+  ```sql
+  SELECT DISTINCT app_name FROM activities ORDER BY app_name ASC
+  ```
+- [ ] TE005 [P] `src-tauri/src/commands/settings.rs`: `get_app_rules`, `add_app_rule(app_name, category)`, `delete_app_rule(id)` 커맨드 추가
+- [ ] TE006 `src-tauri/src/lib.rs`: TE005 커맨드 `invoke_handler`에 등록
+
+### 프론트엔드
+
+- [ ] TE007 [P] `src/types/bindings.ts`: `AppRule { id: number; app_name: string; category: string }` 인터페이스 추가
+- [ ] TE008 [P] `src/services/settings.ts`: `getAppRules`, `addAppRule`, `deleteAppRule` 추가
+- [ ] TE009 [P] `src/services/activity.ts`: `getTrackedApps(): Promise<string[]>` 추가
+- [ ] TE010 `src/components/Settings/AppRuleSettings.tsx`: 앱 규칙 설정 컴포넌트 구현
+  - **추적된 앱 목록 선택**: `getTrackedApps()`로 조회한 앱 이름 드롭다운 (이미 규칙 있는 항목 비활성화)
+  - **직접 입력**: 텍스트 입력창으로 앱 이름 수동 입력
+  - Focus / Neutral / Distraction 선택 드롭다운
+  - 추가된 규칙 목록 표시 + 삭제 버튼
+- [ ] TE011 `src/pages/Settings.tsx`: `<AppRuleSettings />` 섹션 추가 (도메인 규칙 섹션 아래)
 
 ---
 

--- a/specs/001-activity-focus-tracker/tasks.md
+++ b/specs/001-activity-focus-tracker/tasks.md
@@ -242,28 +242,28 @@ Phase 1~10 전체 구현 완료 (2026-03-21). 이하는 v2 확장 Phase.
 
 ### 테스트 먼저 작성 (Red)
 
-- [ ] TA001 [P] `src-tauri/src/commands/onboarding.rs` 테스트: `get_onboarding_status`, `complete_onboarding`, `apply_profession_rules` 단위 테스트
-- [ ] TA002 [P] `src-tauri/src/services/classifier.rs` 테스트: title_rules 우선 적용, 이중용도 도메인 title 매칭 테스트
-- [ ] TA003 [P] `src/__tests__/pages/Onboarding.test.tsx`: 직업 선택 렌더링, 스킵 동작, 완료 후 커맨드 호출 테스트
-- [ ] TA004 [P] `src/__tests__/components/Dropdown/QuickOverride.test.tsx`: 분류 배지 클릭 → 선택기 표시, "이번만"/"항상" 동작 테스트
+- [x] TA001 [P] `src-tauri/src/commands/onboarding.rs` 테스트: `get_onboarding_status`, `complete_onboarding`, `apply_profession_rules` 단위 테스트
+- [x] TA002 [P] `src-tauri/src/services/classifier.rs` 테스트: title_rules 우선 적용, 이중용도 도메인 title 매칭 테스트
+- [x] TA003 [P] `src/__tests__/pages/Onboarding.test.tsx`: 직업 선택 렌더링, 스킵 동작, 완료 후 커맨드 호출 테스트
+- [x] TA004 [P] `src/__tests__/components/Dropdown/QuickOverride.test.tsx`: 분류 배지 클릭 → 선택기 표시, "이번만"/"항상" 동작 테스트
 
 ### 구현 (Green)
 
-- [ ] TA005 `src-tauri/migrations/V5__title_rules_onboarding.sql`: `title_rules` 테이블 + `onboarding_completed` 기본 settings 값 추가
-- [ ] TA006 [P] `src-tauri/src/services/classifier.rs` 업데이트: title_rules 조회 및 우선 적용 로직 추가 (domain + title keyword contains 매칭)
-- [ ] TA007 [P] `src-tauri/src/commands/onboarding.rs` 구현: `get_onboarding_status()`, `complete_onboarding(profession)`, `apply_profession_rules(profession)`, `add_title_rule(domain, keyword, category)`, `get_title_rules()`, `delete_title_rule(id)`
-- [ ] TA008 [P] `src-tauri/src/services/settings.rs` 업데이트: title_rules CRUD 서비스 함수 추가
-- [ ] TA009 `src-tauri/tauri.conf.json` 업데이트: `onboarding` 창 추가 (`width: 520, height: 460, decorations: true, visible: false`)
-- [ ] TA010 `src-tauri/src/lib.rs` 업데이트: 앱 시작 시 `onboarding_completed` 확인 → 미완료 시 onboarding 창 표시, 새 커맨드 등록
-- [ ] TA011 [P] `src-tauri/src/commands/session.rs` 업데이트: 세션 시작/종료 전역 단축키 커맨드 추가 (`register_session_shortcuts`)
-- [ ] TA012 [P] `src/pages/Onboarding.tsx` 구현: Step 1(Welcome) → Step 2(직업 선택) → Step 3(규칙 미리보기+완료) 3단계 플로우
-- [ ] TA013 [P] `src/components/Dropdown/QuickOverride.tsx` 구현: 분류 배지 클릭 → Focus/Neutral/Distraction 선택 → "이번만"/"항상 이렇게" 선택, title_rule 또는 domain_rule 저장
-- [ ] TA014 `src/pages/Dropdown.tsx` 업데이트: 현재 활동에 QuickOverride 컴포넌트 연결, 트레이 아이콘 상태 업데이트 로직 연결
-- [ ] TA015 [P] `src/services/onboarding.ts`: `getOnboardingStatus()`, `completeOnboarding(profession)`, `addTitleRule()`, `getTitleRules()`, `deleteTitleRule()` 서비스 레이어
-- [ ] TA016 `src/App.tsx` 업데이트: `onboarding` 창 라우팅 추가
-- [ ] TA017 [P] `src-tauri/src/lib.rs` 트레이 아이콘 갱신: 1초 루프에서 현재 분류 상태에 따라 🔵/🟢/🟡/🔴 업데이트
-- [ ] TA018 [P] `src/components/Settings/AutoLaunchSettings.tsx` 구현 (`tauri-plugin-autostart` 사용), Settings.tsx에 통합
-- [ ] TA019 `src/App.css` 업데이트: 온보딩 스타일, QuickOverride 스타일
+- [x] TA005 `src-tauri/migrations/V5__title_rules_onboarding.sql`: `title_rules` 테이블 + `onboarding_completed` 기본 settings 값 추가
+- [x] TA006 [P] `src-tauri/src/services/classifier.rs` 업데이트: title_rules 조회 및 우선 적용 로직 추가 (domain + title keyword contains 매칭)
+- [x] TA007 [P] `src-tauri/src/commands/onboarding.rs` 구현: `get_onboarding_status()`, `complete_onboarding(profession)`, `apply_profession_rules(profession)`, `add_title_rule(domain, keyword, category)`, `get_title_rules()`, `delete_title_rule(id)`
+- [x] TA008 [P] `src-tauri/src/services/settings.rs` 업데이트: title_rules CRUD 서비스 함수 추가
+- [x] TA009 `src-tauri/tauri.conf.json` 업데이트: `onboarding` 창 추가 (`width: 520, height: 460, decorations: true, visible: false`)
+- [x] TA010 `src-tauri/src/lib.rs` 업데이트: 앱 시작 시 `onboarding_completed` 확인 → 미완료 시 onboarding 창 표시, 새 커맨드 등록
+- [x] TA011 [P] `src-tauri/src/commands/session.rs` 업데이트: 세션 시작/종료 전역 단축키 커맨드 추가 (`register_session_shortcuts`)
+- [x] TA012 [P] `src/pages/Onboarding.tsx` 구현: Step 1(Welcome) → Step 2(직업 선택) → Step 3(규칙 미리보기+완료) 3단계 플로우
+- [x] TA013 [P] `src/components/Dropdown/QuickOverride.tsx` 구현: 분류 배지 클릭 → Focus/Neutral/Distraction 선택 → "이번만"/"항상 이렇게" 선택, title_rule 또는 domain_rule 저장
+- [x] TA014 `src/pages/Dropdown.tsx` 업데이트: 현재 활동에 QuickOverride 컴포넌트 연결, 트레이 아이콘 상태 업데이트 로직 연결
+- [x] TA015 [P] `src/services/onboarding.ts`: `getOnboardingStatus()`, `completeOnboarding(profession)`, `addTitleRule()`, `getTitleRules()`, `deleteTitleRule()` 서비스 레이어
+- [x] TA016 `src/App.tsx` 업데이트: `onboarding` 창 라우팅 추가
+- [x] TA017 [P] `src-tauri/src/lib.rs` 트레이 아이콘 갱신: 1초 루프에서 현재 분류 상태에 따라 🔵/🟢/🟡/🔴 업데이트
+- [x] TA018 [P] `src/components/Settings/AutoLaunchSettings.tsx` 구현 (`tauri-plugin-autostart` 사용), Settings.tsx에 통합
+- [x] TA019 `src/App.css` 업데이트: 온보딩 스타일, QuickOverride 스타일
 
 ---
 

--- a/specs/002-us6-settings-popup/spec.md
+++ b/specs/002-us6-settings-popup/spec.md
@@ -1,0 +1,115 @@
+# Feature Specification: [FEATURE NAME]
+
+**Feature Branch**: `[###-feature-name]`  
+**Created**: [DATE]  
+**Status**: Draft  
+**Input**: User description: "$ARGUMENTS"
+
+## User Scenarios & Testing *(mandatory)*
+
+<!--
+  IMPORTANT: User stories should be PRIORITIZED as user journeys ordered by importance.
+  Each user story/journey must be INDEPENDENTLY TESTABLE - meaning if you implement just ONE of them,
+  you should still have a viable MVP (Minimum Viable Product) that delivers value.
+  
+  Assign priorities (P1, P2, P3, etc.) to each story, where P1 is the most critical.
+  Think of each story as a standalone slice of functionality that can be:
+  - Developed independently
+  - Tested independently
+  - Deployed independently
+  - Demonstrated to users independently
+-->
+
+### User Story 1 - [Brief Title] (Priority: P1)
+
+[Describe this user journey in plain language]
+
+**Why this priority**: [Explain the value and why it has this priority level]
+
+**Independent Test**: [Describe how this can be tested independently - e.g., "Can be fully tested by [specific action] and delivers [specific value]"]
+
+**Acceptance Scenarios**:
+
+1. **Given** [initial state], **When** [action], **Then** [expected outcome]
+2. **Given** [initial state], **When** [action], **Then** [expected outcome]
+
+---
+
+### User Story 2 - [Brief Title] (Priority: P2)
+
+[Describe this user journey in plain language]
+
+**Why this priority**: [Explain the value and why it has this priority level]
+
+**Independent Test**: [Describe how this can be tested independently]
+
+**Acceptance Scenarios**:
+
+1. **Given** [initial state], **When** [action], **Then** [expected outcome]
+
+---
+
+### User Story 3 - [Brief Title] (Priority: P3)
+
+[Describe this user journey in plain language]
+
+**Why this priority**: [Explain the value and why it has this priority level]
+
+**Independent Test**: [Describe how this can be tested independently]
+
+**Acceptance Scenarios**:
+
+1. **Given** [initial state], **When** [action], **Then** [expected outcome]
+
+---
+
+[Add more user stories as needed, each with an assigned priority]
+
+### Edge Cases
+
+<!--
+  ACTION REQUIRED: The content in this section represents placeholders.
+  Fill them out with the right edge cases.
+-->
+
+- What happens when [boundary condition]?
+- How does system handle [error scenario]?
+
+## Requirements *(mandatory)*
+
+<!--
+  ACTION REQUIRED: The content in this section represents placeholders.
+  Fill them out with the right functional requirements.
+-->
+
+### Functional Requirements
+
+- **FR-001**: System MUST [specific capability, e.g., "allow users to create accounts"]
+- **FR-002**: System MUST [specific capability, e.g., "validate email addresses"]  
+- **FR-003**: Users MUST be able to [key interaction, e.g., "reset their password"]
+- **FR-004**: System MUST [data requirement, e.g., "persist user preferences"]
+- **FR-005**: System MUST [behavior, e.g., "log all security events"]
+
+*Example of marking unclear requirements:*
+
+- **FR-006**: System MUST authenticate users via [NEEDS CLARIFICATION: auth method not specified - email/password, SSO, OAuth?]
+- **FR-007**: System MUST retain user data for [NEEDS CLARIFICATION: retention period not specified]
+
+### Key Entities *(include if feature involves data)*
+
+- **[Entity 1]**: [What it represents, key attributes without implementation]
+- **[Entity 2]**: [What it represents, relationships to other entities]
+
+## Success Criteria *(mandatory)*
+
+<!--
+  ACTION REQUIRED: Define measurable success criteria.
+  These must be technology-agnostic and measurable.
+-->
+
+### Measurable Outcomes
+
+- **SC-001**: [Measurable metric, e.g., "Users can complete account creation in under 2 minutes"]
+- **SC-002**: [Measurable metric, e.g., "System handles 1000 concurrent users without degradation"]
+- **SC-003**: [User satisfaction metric, e.g., "90% of users successfully complete primary task on first attempt"]
+- **SC-004**: [Business metric, e.g., "Reduce support tickets related to [X] by 50%"]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -226,6 +226,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "auto-launch"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f012b8cc0c850f34117ec8252a44418f2e34a2cf501de89e29b241ae5f79471"
+dependencies = [
+ "dirs 4.0.0",
+ "thiserror 1.0.69",
+ "winreg 0.10.1",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -811,11 +822,31 @@ dependencies = [
 
 [[package]]
 name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys 0.3.7",
+]
+
+[[package]]
+name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.5.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users 0.4.6",
+ "winapi",
 ]
 
 [[package]]
@@ -826,7 +857,7 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.5.2",
  "windows-sys 0.61.2",
 ]
 
@@ -938,7 +969,7 @@ dependencies = [
  "rustc_version",
  "toml 0.9.12+spec-1.1.0",
  "vswhom",
- "winreg",
+ "winreg 0.55.0",
 ]
 
 [[package]]
@@ -1098,6 +1129,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-nspanel",
+ "tauri-plugin-autostart",
  "tauri-plugin-global-shortcut",
  "tauri-plugin-opener",
  "tauri-specta",
@@ -3252,6 +3284,17 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
@@ -4075,7 +4118,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "cookie",
- "dirs",
+ "dirs 6.0.0",
  "dunce",
  "embed_plist",
  "getrandom 0.3.4",
@@ -4126,7 +4169,7 @@ checksum = "4bbc990d1dbf57a8e1c7fa2327f2a614d8b757805603c1b9ba5c81bade09fd4d"
 dependencies = [
  "anyhow",
  "cargo_toml",
- "dirs",
+ "dirs 6.0.0",
  "glob",
  "heck 0.5.0",
  "json-patch",
@@ -4212,6 +4255,20 @@ dependencies = [
  "tauri-utils",
  "toml 0.9.12+spec-1.1.0",
  "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-autostart"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "459383cebc193cdd03d1ba4acc40f2c408a7abce419d64bdcd2d745bc2886f70"
+dependencies = [
+ "auto-launch",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4727,7 +4784,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5e85aa143ceb072062fc4d6356c1b520a51d636e7bc8e77ec94be3608e5e80c"
 dependencies = [
  "crossbeam-channel",
- "dirs",
+ "dirs 6.0.0",
  "libappindicator",
  "muda",
  "objc2 0.6.4",
@@ -5629,6 +5686,15 @@ dependencies = [
 
 [[package]]
 name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "winreg"
 version = "0.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
@@ -5741,7 +5807,7 @@ dependencies = [
  "block2 0.6.2",
  "cookie",
  "crossbeam-channel",
- "dirs",
+ "dirs 6.0.0",
  "dom_query",
  "dpi",
  "dunce",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -66,6 +66,126 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43c070bbf59cd3570b6b2dd54cd772527c7c3620fce8be898406dd3ed6adc64c"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -184,6 +304,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
  "objc2 0.6.4",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -406,6 +539,15 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -806,6 +948,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
 
 [[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -820,6 +989,37 @@ dependencies = [
  "serde",
  "serde_core",
  "typeid",
+]
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -898,6 +1098,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-nspanel",
+ "tauri-plugin-opener",
  "tauri-specta",
  "thiserror 1.0.69",
  "tokio",
@@ -993,6 +1194,19 @@ name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -1399,6 +1613,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1706,6 +1926,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-docker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1876,6 +2115,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -2349,10 +2594,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "open"
+version = "5.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43bb73a7fa3799b198970490a51174027ba0d4ec504b03cd08caf513d40024bc"
+dependencies = [
+ "dunce",
+ "is-wsl",
+ "libc",
+ "pathdiff",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "pango"
@@ -2378,6 +2645,12 @@ dependencies = [
  "libc",
  "system-deps",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -2407,6 +2680,12 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "percent-encoding"
@@ -2614,6 +2893,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2643,6 +2933,20 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3085,6 +3389,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.11.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3395,6 +3712,16 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
 
 [[package]]
 name = "simd-adler32"
@@ -3842,6 +4169,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin"
+version = "2.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddde7d51c907b940fb573006cdda9a642d6a7c8153657e88f8a5c3c9290cd4aa"
+dependencies = [
+ "anyhow",
+ "glob",
+ "plist",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "tauri-utils",
+ "toml 0.9.12+spec-1.1.0",
+ "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-opener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc624469b06f59f5a29f874bbc61a2ed737c0f9c23ef09855a292c389c42e83f"
+dependencies = [
+ "dunce",
+ "glob",
+ "objc2-app-kit 0.3.2",
+ "objc2-foundation 0.3.2",
+ "open",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+ "url",
+ "windows",
+ "zbus",
+]
+
+[[package]]
 name = "tauri-runtime"
 version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3967,6 +4333,19 @@ dependencies = [
  "dunce",
  "embed-resource",
  "toml 0.9.12+spec-1.1.0",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4273,7 +4652,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4324,6 +4715,17 @@ name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "unic-char-property"
@@ -5374,6 +5776,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "zbus"
+version = "5.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca82f95dbd3943a40a53cfded6c2d0a2ca26192011846a1810c4256ef92c60bc"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix",
+ "serde",
+ "serde_repr",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow 0.7.15",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897e79616e84aac4b2c46e9132a4f63b93105d54fe8c0e8f6bffc21fa8d49222"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffd8af6d5b78619bab301ff3c560a5bd22426150253db278f164d6cf3b72c50f"
+dependencies = [
+ "serde",
+ "winnow 0.7.15",
+ "zvariant",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5452,3 +5915,43 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zvariant"
+version = "5.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5708299b21903bbe348e94729f22c49c55d04720a004aa350f1f9c122fd2540b"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "winnow 0.7.15",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b59b012ebe9c46656f9cc08d8da8b4c726510aef12559da3e5f1bf72780752c"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f75c23a64ef8f40f13a6989991e643554d9bef1d682a281160cf0c1bc389c5e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.117",
+ "winnow 0.7.15",
+]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1131,6 +1131,7 @@ dependencies = [
  "tauri-nspanel",
  "tauri-plugin-autostart",
  "tauri-plugin-global-shortcut",
+ "tauri-plugin-notification",
  "tauri-plugin-opener",
  "tauri-specta",
  "thiserror 1.0.69",
@@ -2211,6 +2212,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
+name = "mac-notification-sys"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29a16783dd1a47849b8c8133c9cd3eb2112cfbc6901670af3dba47c8bbfb07d3"
+dependencies = [
+ "cc",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+ "time",
+]
+
+[[package]]
 name = "malloc_buf"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2365,6 +2378,20 @@ name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+
+[[package]]
+name = "notify-rust"
+version = "4.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21af20a1b50be5ac5861f74af1a863da53a11c38684d9818d82f1c42f7fdc6c2"
+dependencies = [
+ "futures-lite",
+ "log",
+ "mac-notification-sys",
+ "serde",
+ "tauri-winrt-notification",
+ "zbus",
+]
 
 [[package]]
 name = "num-conv"
@@ -2561,6 +2588,7 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.0",
  "block2 0.6.2",
+ "libc",
  "objc2 0.6.4",
  "objc2-core-foundation",
 ]
@@ -2978,7 +3006,7 @@ checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.13.0",
- "quick-xml",
+ "quick-xml 0.38.4",
  "serde",
  "time",
 ]
@@ -3119,6 +3147,15 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
+version = "0.37.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
 version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
@@ -3196,6 +3233,16 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
@@ -3226,6 +3273,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3241,6 +3298,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -4287,6 +4353,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-notification"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01fc2c5ff41105bd1f7242d8201fdf3efd70749b82fa013a17f2126357d194cc"
+dependencies = [
+ "log",
+ "notify-rust",
+ "rand 0.9.2",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+ "time",
+ "url",
+]
+
+[[package]]
 name = "tauri-plugin-opener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4434,6 +4519,18 @@ dependencies = [
  "dunce",
  "embed-resource",
  "toml 0.9.12+spec-1.1.0",
+]
+
+[[package]]
+name = "tauri-winrt-notification"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b1e66e07de489fe43a46678dd0b8df65e0c973909df1b60ba33874e297ba9b9"
+dependencies = [
+ "quick-xml 0.37.5",
+ "thiserror 2.0.18",
+ "windows",
+ "windows-version",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1098,6 +1098,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-nspanel",
+ "tauri-plugin-global-shortcut",
  "tauri-plugin-opener",
  "tauri-specta",
  "thiserror 1.0.69",
@@ -1366,6 +1367,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1497,6 +1508,24 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "global-hotkey"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9247516746aa8e53411a0db9b62b0e24efbcf6a76e0ba73e5a91b512ddabed7"
+dependencies = [
+ "crossbeam-channel",
+ "keyboard-types",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "once_cell",
+ "serde",
+ "thiserror 2.0.18",
+ "windows-sys 0.59.0",
+ "x11rb",
+ "xkeysym",
+]
 
 [[package]]
 name = "gobject-sys"
@@ -4186,6 +4215,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-global-shortcut"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "424af23c7e88d05e4a1a6fc2c7be077912f8c76bd7900fd50aa2b7cbf5a2c405"
+dependencies = [
+ "global-hotkey",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "tauri-plugin-opener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5751,6 +5795,29 @@ dependencies = [
  "once_cell",
  "pkg-config",
 ]
+
+[[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
+name = "xkeysym"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "yoke"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -32,6 +32,7 @@ refinery = { version = "0.8", features = ["rusqlite"] }
 objc2 = "0.5"
 objc2-foundation = { version = "0.2", features = ["NSString", "NSArray"] }
 objc2-app-kit = { version = "0.2", features = ["NSWorkspace", "NSRunningApplication"] }
+tauri-plugin-notification = "2"
 
 # macOS NSPanel — 전체화면 위에 표시되는 메뉴바 드롭다운 (moa 동일 방식)
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -15,6 +15,7 @@ tauri-build = { version = "2", features = [] }
 [dependencies]
 tauri = { version = "2", features = ["macos-private-api", "tray-icon"] }
 tauri-plugin-opener = "2"
+tauri-plugin-global-shortcut = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -16,6 +16,7 @@ tauri-build = { version = "2", features = [] }
 tauri = { version = "2", features = ["macos-private-api", "tray-icon"] }
 tauri-plugin-opener = "2"
 tauri-plugin-global-shortcut = "2"
+tauri-plugin-autostart = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -14,6 +14,7 @@ tauri-build = { version = "2", features = [] }
 
 [dependencies]
 tauri = { version = "2", features = ["macos-private-api", "tray-icon"] }
+tauri-plugin-opener = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -10,6 +10,7 @@
     "global-shortcut:allow-unregister-all",
     "autostart:allow-enable",
     "autostart:allow-disable",
-    "autostart:allow-is-enabled"
+    "autostart:allow-is-enabled",
+    "notification:default"
   ]
 }

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -2,9 +2,11 @@
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
   "description": "focaro 앱 기본 권한",
-  "windows": ["dropdown", "dashboard"],
+  "windows": ["dropdown", "dashboard", "save-reference", "settings"],
   "permissions": [
     "core:default",
-    "opener:default"
+    "opener:default",
+    "global-shortcut:allow-register",
+    "global-shortcut:allow-unregister-all"
   ]
 }

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -2,11 +2,14 @@
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
   "description": "focaro 앱 기본 권한",
-  "windows": ["dropdown", "dashboard", "save-reference", "settings"],
+  "windows": ["dropdown", "dashboard", "save-reference", "settings", "onboarding"],
   "permissions": [
     "core:default",
     "opener:default",
     "global-shortcut:allow-register",
-    "global-shortcut:allow-unregister-all"
+    "global-shortcut:allow-unregister-all",
+    "autostart:allow-enable",
+    "autostart:allow-disable",
+    "autostart:allow-is-enabled"
   ]
 }

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -4,6 +4,7 @@
   "description": "focaro 앱 기본 권한",
   "windows": ["dropdown", "dashboard"],
   "permissions": [
-    "core:default"
+    "core:default",
+    "opener:default"
   ]
 }

--- a/src-tauri/migrations/V3__activity_title.sql
+++ b/src-tauri/migrations/V3__activity_title.sql
@@ -1,3 +1,2 @@
--- V3: activities 테이블에 title 컬럼 추가
-
+-- V3: activities 테이블에 페이지 타이틀 컬럼 추가
 ALTER TABLE activities ADD COLUMN title TEXT;

--- a/src-tauri/migrations/V3__activity_title.sql
+++ b/src-tauri/migrations/V3__activity_title.sql
@@ -1,0 +1,2 @@
+-- V3: activities 테이블에 페이지 타이틀 컬럼 추가
+ALTER TABLE activities ADD COLUMN title TEXT;

--- a/src-tauri/migrations/V3__activity_title.sql
+++ b/src-tauri/migrations/V3__activity_title.sql
@@ -1,2 +1,3 @@
--- V3: activities 테이블에 페이지 타이틀 컬럼 추가
+-- V3: activities 테이블에 title 컬럼 추가
+
 ALTER TABLE activities ADD COLUMN title TEXT;

--- a/src-tauri/migrations/V4__shortcut_setting.sql
+++ b/src-tauri/migrations/V4__shortcut_setting.sql
@@ -1,0 +1,2 @@
+-- V4: 전역 단축키 기본 설정 추가
+INSERT OR IGNORE INTO settings (key, value) VALUES ('shortcut_save_ref', 'CmdOrCtrl+Shift+R');

--- a/src-tauri/migrations/V5__title_rules_onboarding.sql
+++ b/src-tauri/migrations/V5__title_rules_onboarding.sql
@@ -1,0 +1,15 @@
+-- V5: title_rules 테이블 + 온보딩 설정 추가
+
+CREATE TABLE IF NOT EXISTS title_rules (
+    id       INTEGER PRIMARY KEY AUTOINCREMENT,
+    domain   TEXT NOT NULL,
+    keyword  TEXT NOT NULL,  -- 소문자 변환 후 title contains 매칭
+    category TEXT NOT NULL
+             CHECK (category IN ('Focus', 'Neutral', 'Distraction'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_title_rules_domain ON title_rules(domain);
+
+INSERT OR IGNORE INTO settings (key, value) VALUES ('onboarding_completed', 'false');
+INSERT OR IGNORE INTO settings (key, value) VALUES ('shortcut_session_start', 'CmdOrCtrl+Shift+S');
+INSERT OR IGNORE INTO settings (key, value) VALUES ('shortcut_session_end', 'CmdOrCtrl+Shift+E');

--- a/src-tauri/migrations/V6__goals.sql
+++ b/src-tauri/migrations/V6__goals.sql
@@ -1,0 +1,10 @@
+-- V6: 일일 집중 목표 테이블 추가
+CREATE TABLE IF NOT EXISTS session_goals (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    date        TEXT NOT NULL UNIQUE,  -- YYYY-MM-DD
+    target_secs INTEGER NOT NULL DEFAULT 7200  -- 기본 2시간
+);
+
+INSERT OR IGNORE INTO settings (key, value) VALUES ('default_goal_secs', '7200');
+INSERT OR IGNORE INTO settings (key, value) VALUES ('notify_low_focus_threshold', '40');
+INSERT OR IGNORE INTO settings (key, value) VALUES ('notify_enabled', 'true');

--- a/src-tauri/migrations/V7__app_rules.sql
+++ b/src-tauri/migrations/V7__app_rules.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS app_rules (
+  id       INTEGER PRIMARY KEY AUTOINCREMENT,
+  app_name TEXT    NOT NULL UNIQUE,
+  category TEXT    NOT NULL CHECK (category IN ('Focus', 'Neutral', 'Distraction'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_app_rules_app_name ON app_rules(app_name);

--- a/src-tauri/src/commands/activity.rs
+++ b/src-tauri/src/commands/activity.rs
@@ -3,6 +3,7 @@ use tauri::State;
 
 use crate::errors::AppError;
 use crate::services::{activity as activity_svc, db::DbPool};
+use rusqlite::params;
 use crate::state::app_state::AppState;
 
 #[derive(Debug, serde::Serialize)]
@@ -180,4 +181,22 @@ pub async fn get_daily_focus_stats(
         neutral_percentage: np,
         distraction_percentage: dp,
     })
+}
+
+/// 지금까지 추적된 고유 앱 이름 목록 반환 (앱 규칙 설정용)
+#[tauri::command]
+pub async fn get_tracked_apps(
+    state: State<'_, Mutex<AppState>>,
+) -> Result<Vec<String>, AppError> {
+    let pool = get_pool(&state);
+    let conn = pool.get().map_err(AppError::from)?;
+    let mut stmt = conn
+        .prepare("SELECT DISTINCT app_name FROM activities ORDER BY app_name ASC")
+        .map_err(AppError::from)?;
+    let apps = stmt
+        .query_map(params![], |row| row.get(0))
+        .map_err(AppError::from)?
+        .filter_map(|r| r.ok())
+        .collect();
+    Ok(apps)
 }

--- a/src-tauri/src/commands/activity.rs
+++ b/src-tauri/src/commands/activity.rs
@@ -1,0 +1,139 @@
+use std::sync::Mutex;
+use tauri::State;
+
+use crate::errors::AppError;
+use crate::services::{activity as activity_svc, db::DbPool};
+use crate::state::app_state::AppState;
+
+#[derive(Debug, serde::Serialize)]
+pub struct ActivityRow {
+    pub id: String,
+    pub session_id: String,
+    pub app_name: String,
+    pub url: Option<String>,
+    pub domain: Option<String>,
+    pub title: Option<String>,
+    pub classification: String,
+    pub started_at: String,
+    pub duration_secs: Option<i64>,
+}
+
+#[derive(Debug, serde::Serialize)]
+pub struct SessionEvent {
+    pub session_id: String,
+    pub event_type: String,
+    pub timestamp: String,
+}
+
+#[derive(Debug, serde::Serialize)]
+pub struct DomainSummary {
+    pub domain: String,
+    pub total_secs: i64,
+    pub classification: String,
+}
+
+#[derive(Debug, serde::Serialize)]
+pub struct DailyFocusStats {
+    pub total_secs: i64,
+    pub focus_secs: i64,
+    pub neutral_secs: i64,
+    pub distraction_secs: i64,
+    pub focus_percentage: f64,
+    pub neutral_percentage: f64,
+    pub distraction_percentage: f64,
+}
+
+fn get_pool(state: &State<'_, Mutex<AppState>>) -> DbPool {
+    let s = state.lock().unwrap();
+    s.db_pool.clone()
+}
+
+/// 특정 날짜(UTC, "YYYY-MM-DD")의 활동 타임라인
+#[tauri::command]
+pub async fn get_activity_timeline(
+    date: String,
+    state: State<'_, Mutex<AppState>>,
+) -> Result<Vec<ActivityRow>, AppError> {
+    let pool = get_pool(&state);
+    let rows = activity_svc::query_activity_timeline(&pool, &date)?;
+    Ok(rows
+        .into_iter()
+        .map(|r| ActivityRow {
+            id: r.id,
+            session_id: r.session_id,
+            app_name: r.app_name,
+            url: r.url,
+            domain: r.domain,
+            title: r.title,
+            classification: r.classification,
+            started_at: r.started_at,
+            duration_secs: r.duration_secs,
+        })
+        .collect())
+}
+
+/// 특정 날짜(UTC)의 Top Sites (도메인별 누적 시간)
+#[tauri::command]
+pub async fn get_top_sites(
+    date: String,
+    limit: u32,
+    state: State<'_, Mutex<AppState>>,
+) -> Result<Vec<DomainSummary>, AppError> {
+    let pool = get_pool(&state);
+    let sites = activity_svc::query_top_sites(&pool, &date, limit)?;
+    Ok(sites
+        .into_iter()
+        .map(|s| DomainSummary {
+            domain: s.domain,
+            total_secs: s.total_secs,
+            classification: s.classification,
+        })
+        .collect())
+}
+
+/// 특정 날짜(UTC)의 세션 시작/종료 이벤트
+#[tauri::command]
+pub async fn get_session_events(
+    date: String,
+    state: State<'_, Mutex<AppState>>,
+) -> Result<Vec<SessionEvent>, AppError> {
+    let pool = get_pool(&state);
+    let events = activity_svc::query_session_events(&pool, &date)?;
+    Ok(events
+        .into_iter()
+        .map(|e| SessionEvent {
+            session_id: e.session_id,
+            event_type: e.event_type,
+            timestamp: e.timestamp,
+        })
+        .collect())
+}
+
+/// 특정 날짜(UTC)의 Focus/Neutral/Distraction 일별 통계
+#[tauri::command]
+pub async fn get_daily_focus_stats(
+    date: String,
+    state: State<'_, Mutex<AppState>>,
+) -> Result<DailyFocusStats, AppError> {
+    let pool = get_pool(&state);
+    let s = activity_svc::query_daily_focus_stats(&pool, &date)?;
+    let (fp, np, dp) = if s.total_secs > 0 {
+        let t = s.total_secs as f64;
+        (
+            (s.focus_secs as f64 / t) * 100.0,
+            (s.neutral_secs as f64 / t) * 100.0,
+            (s.distraction_secs as f64 / t) * 100.0,
+        )
+    } else {
+        (0.0, 0.0, 0.0)
+    };
+    Ok(DailyFocusStats {
+        total_secs: s.total_secs,
+        focus_secs: s.focus_secs,
+        neutral_secs: s.neutral_secs,
+        distraction_secs: s.distraction_secs,
+        focus_percentage: fp,
+        neutral_percentage: np,
+        distraction_percentage: dp,
+    })
+}

--- a/src-tauri/src/commands/activity.rs
+++ b/src-tauri/src/commands/activity.rs
@@ -109,6 +109,50 @@ pub async fn get_session_events(
         .collect())
 }
 
+/// 주간 요일별 집중 통계 (start_date: 해당 주 월요일 YYYY-MM-DD)
+#[derive(Debug, serde::Serialize)]
+pub struct WeeklyDayStat {
+    pub date: String,
+    pub focus_secs: i64,
+    pub total_secs: i64,
+}
+
+#[tauri::command]
+pub async fn get_weekly_report(
+    start_date: String,
+    state: State<'_, Mutex<AppState>>,
+) -> Result<Vec<WeeklyDayStat>, AppError> {
+    let pool = get_pool(&state);
+    let rows = activity_svc::query_weekly_report(&pool, &start_date)?;
+    Ok(rows.into_iter().map(|r| WeeklyDayStat {
+        date: r.date,
+        focus_secs: r.focus_secs,
+        total_secs: r.total_secs,
+    }).collect())
+}
+
+/// 최근 N일 집중도 트렌드
+#[derive(Debug, serde::Serialize)]
+pub struct TrendPoint {
+    pub date: String,
+    pub focus_pct: f64,
+    pub focus_secs: i64,
+}
+
+#[tauri::command]
+pub async fn get_trend(
+    days: i64,
+    state: State<'_, Mutex<AppState>>,
+) -> Result<Vec<TrendPoint>, AppError> {
+    let pool = get_pool(&state);
+    let rows = activity_svc::query_trend(&pool, days)?;
+    Ok(rows.into_iter().map(|r| TrendPoint {
+        date: r.date,
+        focus_pct: r.focus_pct,
+        focus_secs: r.focus_secs,
+    }).collect())
+}
+
 /// 특정 날짜(UTC)의 Focus/Neutral/Distraction 일별 통계
 #[tauri::command]
 pub async fn get_daily_focus_stats(

--- a/src-tauri/src/commands/export.rs
+++ b/src-tauri/src/commands/export.rs
@@ -1,0 +1,104 @@
+use std::sync::Mutex;
+use tauri::{AppHandle, Manager, State};
+
+use crate::errors::AppError;
+use crate::services::{activity as activity_svc, db::DbPool};
+use crate::state::app_state::AppState;
+
+fn get_pool(state: &State<'_, Mutex<AppState>>) -> DbPool {
+    state.lock().unwrap().db_pool.clone()
+}
+
+fn format_csv(rows: &[activity_svc::ActivityRow]) -> String {
+    let mut out = String::from(
+        "date,app_name,domain,title,classification,duration_secs,url\n",
+    );
+    for r in rows {
+        let domain = r.domain.as_deref().unwrap_or("");
+        let url = r.url.as_deref().unwrap_or("");
+        let title = r.title.as_deref().unwrap_or("");
+        let duration = r.duration_secs.unwrap_or(0);
+        // Escape fields that may contain commas/quotes
+        let escape = |s: &str| {
+            if s.contains(',') || s.contains('"') || s.contains('\n') {
+                format!("\"{}\"", s.replace('"', "\"\""))
+            } else {
+                s.to_string()
+            }
+        };
+        out.push_str(&format!(
+            "{},{},{},{},{},{},{}\n",
+            &r.started_at[..10],
+            escape(&r.app_name),
+            escape(domain),
+            escape(title),
+            r.classification,
+            duration,
+            escape(url),
+        ));
+    }
+    out
+}
+
+fn format_json(rows: &[activity_svc::ActivityRow]) -> Result<String, AppError> {
+    #[derive(serde::Serialize)]
+    struct ExportRow<'a> {
+        date: &'a str,
+        app_name: &'a str,
+        domain: Option<&'a str>,
+        title: Option<&'a str>,
+        classification: &'a str,
+        duration_secs: Option<i64>,
+        url: Option<&'a str>,
+    }
+
+    let items: Vec<ExportRow> = rows
+        .iter()
+        .map(|r| ExportRow {
+            date: &r.started_at[..10],
+            app_name: &r.app_name,
+            domain: r.domain.as_deref(),
+            title: r.title.as_deref(),
+            classification: &r.classification,
+            duration_secs: r.duration_secs,
+            url: r.url.as_deref(),
+        })
+        .collect();
+
+    serde_json::to_string_pretty(&items).map_err(|e| AppError::Internal(e.to_string()))
+}
+
+#[tauri::command]
+pub async fn export_data(
+    start_date: String,
+    end_date: String,
+    format: String,
+    state: State<'_, Mutex<AppState>>,
+    app: AppHandle,
+) -> Result<String, AppError> {
+    let pool = get_pool(&state);
+    let rows = activity_svc::query_export_activities(&pool, &start_date, &end_date)?;
+
+    if rows.is_empty() {
+        return Err(AppError::NotFound("해당 기간에 활동 데이터가 없습니다".into()));
+    }
+
+    let (content, ext) = match format.as_str() {
+        "json" => (format_json(&rows)?, "json"),
+        _ => (format_csv(&rows), "csv"),
+    };
+
+    let downloads = app
+        .path()
+        .download_dir()
+        .map_err(|e| AppError::Internal(e.to_string()))?;
+
+    let timestamp = chrono::Local::now().format("%Y%m%d-%H%M%S");
+    let filename = format!("focaro-export-{}-to-{}-{}.{}", start_date, end_date, timestamp, ext);
+    let full_path = downloads.join(&filename);
+
+    std::fs::write(&full_path, content)
+        .map_err(|e| AppError::Internal(e.to_string()))?;
+
+    Ok(full_path.to_string_lossy().to_string())
+}

--- a/src-tauri/src/commands/goal.rs
+++ b/src-tauri/src/commands/goal.rs
@@ -1,0 +1,41 @@
+use std::sync::Mutex;
+use tauri::State;
+
+use crate::errors::AppError;
+use crate::models::goal::{DailyGoal, GoalProgress};
+use crate::services::goal as svc;
+use crate::state::app_state::AppState;
+
+#[tauri::command]
+pub async fn get_daily_goal(
+    date: Option<String>,
+    state: State<'_, Mutex<AppState>>,
+) -> Result<DailyGoal, AppError> {
+    let pool = state.lock().map_err(|e| AppError::Internal(e.to_string()))?.db_pool.clone();
+    let conn = pool.get().map_err(AppError::from)?;
+    let d = date.unwrap_or_else(svc::today);
+    svc::get_daily_goal(&conn, &d)
+}
+
+#[tauri::command]
+pub async fn set_daily_goal(
+    date: Option<String>,
+    target_secs: i64,
+    state: State<'_, Mutex<AppState>>,
+) -> Result<DailyGoal, AppError> {
+    let pool = state.lock().map_err(|e| AppError::Internal(e.to_string()))?.db_pool.clone();
+    let conn = pool.get().map_err(AppError::from)?;
+    let d = date.unwrap_or_else(svc::today);
+    svc::set_daily_goal(&conn, &d, target_secs)
+}
+
+#[tauri::command]
+pub async fn get_goal_progress(
+    date: Option<String>,
+    state: State<'_, Mutex<AppState>>,
+) -> Result<GoalProgress, AppError> {
+    let pool = state.lock().map_err(|e| AppError::Internal(e.to_string()))?.db_pool.clone();
+    let conn = pool.get().map_err(AppError::from)?;
+    let d = date.unwrap_or_else(svc::today);
+    svc::get_goal_progress(&conn, &d)
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod activity;
+pub mod goal;
 pub mod onboarding;
 pub mod reference;
 pub mod session;

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,2 +1,3 @@
+pub mod activity;
 pub mod reference;
 pub mod session;

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod activity;
+pub mod export;
 pub mod goal;
 pub mod onboarding;
 pub mod reference;

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,3 +1,4 @@
 pub mod activity;
 pub mod reference;
 pub mod session;
+pub mod settings;

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod activity;
+pub mod onboarding;
 pub mod reference;
 pub mod session;
 pub mod settings;

--- a/src-tauri/src/commands/onboarding.rs
+++ b/src-tauri/src/commands/onboarding.rs
@@ -1,0 +1,97 @@
+use std::sync::Mutex;
+use tauri::State;
+
+use crate::errors::AppError;
+use crate::models::onboarding::{Profession, TitleRule};
+use crate::services::onboarding as svc;
+use crate::state::app_state::AppState;
+
+#[tauri::command]
+pub async fn get_onboarding_status(
+    state: State<'_, Mutex<AppState>>,
+) -> Result<bool, AppError> {
+    let pool = {
+        let s = state.lock().map_err(|e| AppError::Internal(e.to_string()))?;
+        s.db_pool.clone()
+    };
+    let conn = pool.get().map_err(AppError::from)?;
+    Ok(svc::is_onboarding_completed(&conn))
+}
+
+#[tauri::command]
+pub async fn complete_onboarding(
+    state: State<'_, Mutex<AppState>>,
+) -> Result<(), AppError> {
+    let pool = {
+        let s = state.lock().map_err(|e| AppError::Internal(e.to_string()))?;
+        s.db_pool.clone()
+    };
+    let conn = pool.get().map_err(AppError::from)?;
+    svc::complete_onboarding(&conn)
+}
+
+#[tauri::command]
+pub async fn apply_profession_rules(
+    profession: Profession,
+    state: State<'_, Mutex<AppState>>,
+) -> Result<(), AppError> {
+    let pool = {
+        let s = state.lock().map_err(|e| AppError::Internal(e.to_string()))?;
+        s.db_pool.clone()
+    };
+    svc::apply_profession_rules(&pool, &profession)
+}
+
+#[tauri::command]
+pub async fn get_title_rules(
+    state: State<'_, Mutex<AppState>>,
+) -> Result<Vec<TitleRule>, AppError> {
+    let pool = {
+        let s = state.lock().map_err(|e| AppError::Internal(e.to_string()))?;
+        s.db_pool.clone()
+    };
+    let conn = pool.get().map_err(AppError::from)?;
+    svc::get_title_rules(&conn)
+}
+
+#[tauri::command]
+pub async fn add_title_rule(
+    domain: String,
+    keyword: String,
+    category: String,
+    state: State<'_, Mutex<AppState>>,
+) -> Result<TitleRule, AppError> {
+    let pool = {
+        let s = state.lock().map_err(|e| AppError::Internal(e.to_string()))?;
+        s.db_pool.clone()
+    };
+    let conn = pool.get().map_err(AppError::from)?;
+    svc::add_title_rule(&conn, &domain, &keyword, &category)
+}
+
+#[tauri::command]
+pub async fn delete_title_rule(
+    id: i64,
+    state: State<'_, Mutex<AppState>>,
+) -> Result<(), AppError> {
+    let pool = {
+        let s = state.lock().map_err(|e| AppError::Internal(e.to_string()))?;
+        s.db_pool.clone()
+    };
+    let conn = pool.get().map_err(AppError::from)?;
+    svc::delete_title_rule(&conn, id)
+}
+
+#[tauri::command]
+pub async fn override_activity_classification(
+    activity_id: String,
+    category: String,
+    state: State<'_, Mutex<AppState>>,
+) -> Result<(), AppError> {
+    let pool = {
+        let s = state.lock().map_err(|e| AppError::Internal(e.to_string()))?;
+        s.db_pool.clone()
+    };
+    let conn = pool.get().map_err(AppError::from)?;
+    svc::override_activity_classification(&conn, &activity_id, &category)
+}

--- a/src-tauri/src/commands/reference.rs
+++ b/src-tauri/src/commands/reference.rs
@@ -2,7 +2,7 @@ use std::sync::Mutex;
 use tauri::State;
 
 use crate::errors::AppError;
-use crate::models::reference::{Reference, SaveReferenceInput};
+use crate::models::reference::{Reference, SaveReferenceInput, UpdateReferenceInput};
 use crate::services::reference as reference_svc;
 use crate::state::app_state::AppState;
 
@@ -34,4 +34,28 @@ pub async fn get_references(
         state.db_pool.clone()
     };
     reference_svc::get_references(&pool, session_id.as_deref())
+}
+
+#[tauri::command]
+pub async fn delete_reference(
+    id: String,
+    state: State<'_, Mutex<AppState>>,
+) -> Result<(), AppError> {
+    let pool = {
+        let state = state.lock().map_err(|e| AppError::Internal(e.to_string()))?;
+        state.db_pool.clone()
+    };
+    reference_svc::delete_reference(&pool, &id)
+}
+
+#[tauri::command]
+pub async fn update_reference(
+    input: UpdateReferenceInput,
+    state: State<'_, Mutex<AppState>>,
+) -> Result<Reference, AppError> {
+    let pool = {
+        let state = state.lock().map_err(|e| AppError::Internal(e.to_string()))?;
+        state.db_pool.clone()
+    };
+    reference_svc::update_reference(&pool, &input.id, &input.title, input.tags)
 }

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -306,6 +306,22 @@ pub async fn get_current_title() -> Result<Option<String>, AppError> {
     Ok(None)
 }
 
+/// Accessibility 권한 여부 확인 (macOS 전용)
+/// 권한 없으면 프론트엔드에서 안내 배너 표시
+#[tauri::command]
+pub async fn check_accessibility_permission() -> bool {
+    #[cfg(target_os = "macos")]
+    {
+        #[link(name = "ApplicationServices", kind = "framework")]
+        extern "C" {
+            fn AXIsProcessTrusted() -> bool;
+        }
+        unsafe { AXIsProcessTrusted() }
+    }
+    #[cfg(not(target_os = "macos"))]
+    true
+}
+
 #[tauri::command]
 pub async fn open_dashboard(app_handle: AppHandle) -> Result<(), AppError> {
     use tauri::Manager;

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -285,6 +285,28 @@ pub async fn get_current_url() -> Result<Option<String>, AppError> {
 }
 
 #[tauri::command]
+pub async fn get_current_title() -> Result<Option<String>, AppError> {
+    #[cfg(target_os = "macos")]
+    {
+        use crate::services::browser;
+        use objc2_app_kit::NSWorkspace;
+        let app_name = unsafe {
+            let workspace = NSWorkspace::sharedWorkspace();
+            workspace
+                .frontmostApplication()
+                .and_then(|a| a.localizedName())
+                .map(|s| s.to_string())
+        };
+        if let Some(name) = app_name {
+            return Ok(browser::get_browser_title(&name));
+        }
+        return Ok(None);
+    }
+    #[cfg(not(target_os = "macos"))]
+    Ok(None)
+}
+
+#[tauri::command]
 pub async fn open_dashboard(app_handle: AppHandle) -> Result<(), AppError> {
     use tauri::Manager;
     if let Some(window) = app_handle.get_webview_window("dashboard") {
@@ -293,3 +315,4 @@ pub async fn open_dashboard(app_handle: AppHandle) -> Result<(), AppError> {
     }
     Ok(())
 }
+

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -3,6 +3,7 @@ use tauri::{Manager, State};
 
 use crate::errors::AppError;
 use crate::models::settings::{AppSettings, ClassificationRule};
+use crate::services::settings::AppRule;
 use crate::state::app_state::AppState;
 
 // ─── 커맨드 ─────────────────────────────────────────────────────────────────
@@ -75,6 +76,36 @@ pub async fn open_save_reference_window(app: tauri::AppHandle) -> Result<(), App
         let _ = win.set_focus();
     }
     Ok(())
+}
+
+#[tauri::command]
+pub async fn get_app_rules(
+    state: State<'_, Mutex<AppState>>,
+) -> Result<Vec<AppRule>, AppError> {
+    let pool = state.lock().unwrap().db_pool.clone();
+    let conn = pool.get().map_err(AppError::from)?;
+    crate::services::settings::get_app_rules(&conn)
+}
+
+#[tauri::command]
+pub async fn add_app_rule(
+    app_name: String,
+    category: String,
+    state: State<'_, Mutex<AppState>>,
+) -> Result<AppRule, AppError> {
+    let pool = state.lock().unwrap().db_pool.clone();
+    let conn = pool.get().map_err(AppError::from)?;
+    crate::services::settings::add_app_rule(&conn, &app_name, &category)
+}
+
+#[tauri::command]
+pub async fn delete_app_rule(
+    id: i64,
+    state: State<'_, Mutex<AppState>>,
+) -> Result<(), AppError> {
+    let pool = state.lock().unwrap().db_pool.clone();
+    let conn = pool.get().map_err(AppError::from)?;
+    crate::services::settings::delete_app_rule(&conn, id)
 }
 
 // ─── 테스트 ─────────────────────────────────────────────────────────────────

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -24,8 +24,8 @@ pub async fn update_settings(
     let conn = pool.get().map_err(AppError::from)?;
     crate::services::settings::update_settings(&conn, &settings)?;
 
-    // 단축키 변경 시 재등록
-    crate::register_save_reference_shortcut(&app, &settings.shortcut_save_ref);
+    // 단축키 변경 시 전체 재등록
+    crate::register_all_shortcuts(&app, &settings);
     Ok(())
 }
 

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -1,0 +1,144 @@
+use std::sync::Mutex;
+use tauri::{Manager, State};
+
+use crate::errors::AppError;
+use crate::models::settings::{AppSettings, ClassificationRule};
+use crate::state::app_state::AppState;
+
+// ─── 커맨드 ─────────────────────────────────────────────────────────────────
+
+#[tauri::command]
+pub async fn get_settings(state: State<'_, Mutex<AppState>>) -> Result<AppSettings, AppError> {
+    let pool = state.lock().unwrap().db_pool.clone();
+    let conn = pool.get().map_err(AppError::from)?;
+    crate::services::settings::get_settings(&conn)
+}
+
+#[tauri::command]
+pub async fn update_settings(
+    state: State<'_, Mutex<AppState>>,
+    app: tauri::AppHandle,
+    settings: AppSettings,
+) -> Result<(), AppError> {
+    let pool = state.lock().unwrap().db_pool.clone();
+    let conn = pool.get().map_err(AppError::from)?;
+    crate::services::settings::update_settings(&conn, &settings)?;
+
+    // 단축키 변경 시 재등록
+    crate::register_save_reference_shortcut(&app, &settings.shortcut_save_ref);
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn get_classification_rules(
+    state: State<'_, Mutex<AppState>>,
+) -> Result<Vec<ClassificationRule>, AppError> {
+    let pool = state.lock().unwrap().db_pool.clone();
+    let conn = pool.get().map_err(AppError::from)?;
+    crate::services::settings::get_classification_rules(&conn)
+}
+
+#[tauri::command]
+pub async fn add_classification_rule(
+    state: State<'_, Mutex<AppState>>,
+    domain: String,
+    category: String,
+) -> Result<ClassificationRule, AppError> {
+    let pool = state.lock().unwrap().db_pool.clone();
+    let conn = pool.get().map_err(AppError::from)?;
+    crate::services::settings::add_classification_rule(&conn, &domain, &category)
+}
+
+#[tauri::command]
+pub async fn delete_classification_rule(
+    state: State<'_, Mutex<AppState>>,
+    id: i64,
+) -> Result<(), AppError> {
+    let pool = state.lock().unwrap().db_pool.clone();
+    let conn = pool.get().map_err(AppError::from)?;
+    crate::services::settings::delete_classification_rule(&conn, id)
+}
+
+#[tauri::command]
+pub async fn open_settings_window(app: tauri::AppHandle) -> Result<(), AppError> {
+    if let Some(win) = app.get_webview_window("settings") {
+        let _ = win.show();
+        let _ = win.set_focus();
+    }
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn open_save_reference_window(app: tauri::AppHandle) -> Result<(), AppError> {
+    if let Some(win) = app.get_webview_window("save-reference") {
+        let _ = win.show();
+        let _ = win.set_focus();
+    }
+    Ok(())
+}
+
+// ─── 테스트 ─────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use rusqlite::Connection;
+
+    use crate::services::db;
+    use crate::services::settings as svc;
+
+    fn setup() -> Connection {
+        let mut conn = Connection::open_in_memory().unwrap();
+        db::run_migrations(&mut conn).unwrap();
+        conn
+    }
+
+    #[test]
+    fn test_get_settings_returns_defaults() {
+        let conn = setup();
+        let s = svc::get_settings(&conn).unwrap();
+        assert_eq!(s.retention_days, 30);
+        assert_eq!(s.shortcut_save_ref, "CmdOrCtrl+Shift+R");
+    }
+
+    #[test]
+    fn test_update_settings_persists() {
+        let conn = setup();
+        let mut s = svc::get_settings(&conn).unwrap();
+        s.retention_days = 7;
+        s.shortcut_save_ref = "CmdOrCtrl+Shift+S".to_string();
+        svc::update_settings(&conn, &s).unwrap();
+
+        let updated = svc::get_settings(&conn).unwrap();
+        assert_eq!(updated.retention_days, 7);
+        assert_eq!(updated.shortcut_save_ref, "CmdOrCtrl+Shift+S");
+    }
+
+    #[test]
+    fn test_get_classification_rules_returns_defaults() {
+        let conn = setup();
+        let rules = svc::get_classification_rules(&conn).unwrap();
+        assert!(!rules.is_empty());
+        assert!(rules.iter().any(|r| r.domain == "github.com" && r.category == "Focus"));
+    }
+
+    #[test]
+    fn test_add_classification_rule_and_retrieve() {
+        let conn = setup();
+        let rule = svc::add_classification_rule(&conn, "example.com", "Distraction").unwrap();
+        assert_eq!(rule.domain, "example.com");
+        assert_eq!(rule.category, "Distraction");
+
+        let rules = svc::get_classification_rules(&conn).unwrap();
+        assert!(rules.iter().any(|r| r.domain == "example.com"));
+    }
+
+    #[test]
+    fn test_delete_classification_rule() {
+        let conn = setup();
+        let rule = svc::add_classification_rule(&conn, "todelete.com", "Neutral").unwrap();
+        svc::delete_classification_rule(&conn, rule.id).unwrap();
+
+        let rules = svc::get_classification_rules(&conn).unwrap();
+        assert!(!rules.iter().any(|r| r.domain == "todelete.com"));
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -20,6 +20,9 @@ use state::app_state::AppState;
 pub fn run() {
     let mut builder = tauri::Builder::default();
 
+    // opener 플러그인 — URL/파일을 기본 앱으로 열기, 크로스플랫폼 지원
+    builder = builder.plugin(tauri_plugin_opener::init());
+
     // NSPanel 플러그인 — 전체화면 앱 위에 표시되는 메뉴바 드롭다운 구현
     #[cfg(target_os = "macos")]
     {
@@ -53,6 +56,18 @@ pub fn run() {
             // NSWindow → NSPanel 변환 + 전체화면 위에 뜨도록 설정
             #[cfg(target_os = "macos")]
             init_menubar_panel(app.handle(), &dropdown);
+
+            // 대시보드 창: X로 닫아도 파괴되지 않고 숨기기만 함
+            // → 재오픈 시 get_webview_window("dashboard")가 항상 Some을 반환
+            if let Some(dashboard) = app.get_webview_window("dashboard") {
+                let win = dashboard.clone();
+                dashboard.on_window_event(move |event| {
+                    if let tauri::WindowEvent::CloseRequested { api, .. } = event {
+                        api.prevent_close();
+                        let _ = win.hide();
+                    }
+                });
+            }
 
             // 트레이 우클릭 메뉴
             let quit_item = MenuItem::with_id(app, "quit", "focaro 종료", true, None::<&str>)?;
@@ -120,8 +135,15 @@ pub fn run() {
             commands::session::get_top_apps,
             commands::session::get_current_app,
             commands::session::get_current_url,
+            commands::session::get_current_title,
             commands::reference::save_reference,
             commands::reference::get_references,
+            commands::reference::delete_reference,
+            commands::reference::update_reference,
+            commands::activity::get_activity_timeline,
+            commands::activity::get_top_sites,
+            commands::activity::get_daily_focus_stats,
+            commands::activity::get_session_events,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -48,6 +48,24 @@ pub fn run() {
             let app_state = AppState::new(pool);
             app.manage(Mutex::new(app_state));
 
+            // 앱 시작 시 보관 기간 초과 데이터 아카이빙
+            {
+                let state = app.state::<Mutex<AppState>>();
+                let pool = state.lock().unwrap().db_pool.clone();
+                let retention_days = {
+                    let conn = pool.get().expect("DB 연결 실패");
+                    services::settings::get_settings(&conn)
+                        .map(|s| s.retention_days)
+                        .unwrap_or(30)
+                };
+                // retention_days=0은 무제한 (아카이빙 없음)
+                if retention_days > 0 {
+                    if let Err(e) = services::archive::archive_old_data(&pool, retention_days) {
+                        eprintln!("아카이빙 실패 (무시하고 계속): {e}");
+                    }
+                }
+            }
+
             // 메뉴바 전용 앱: 독 아이콘 숨김, 앱 활성화 없이 창 표시 가능
             #[cfg(target_os = "macos")]
             app.set_activation_policy(tauri::ActivationPolicy::Accessory);
@@ -172,6 +190,7 @@ pub fn run() {
             commands::session::get_current_app,
             commands::session::get_current_url,
             commands::session::get_current_title,
+            commands::session::check_accessibility_permission,
             commands::reference::save_reference,
             commands::reference::get_references,
             commands::reference::delete_reference,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -239,6 +239,7 @@ pub fn run() {
             commands::onboarding::add_title_rule,
             commands::onboarding::delete_title_rule,
             commands::onboarding::override_activity_classification,
+            commands::export::export_data,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -220,6 +220,8 @@ pub fn run() {
             commands::activity::get_top_sites,
             commands::activity::get_daily_focus_stats,
             commands::activity::get_session_events,
+            commands::activity::get_weekly_report,
+            commands::activity::get_trend,
             commands::settings::get_settings,
             commands::settings::update_settings,
             commands::settings::get_classification_rules,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -16,12 +16,16 @@ use tauri_nspanel::ManagerExt;
 
 use services::db;
 use state::app_state::AppState;
+use tauri_plugin_global_shortcut::{GlobalShortcutExt, Shortcut, ShortcutState};
 
 pub fn run() {
     let mut builder = tauri::Builder::default();
 
     // opener 플러그인 — URL/파일을 기본 앱으로 열기, 크로스플랫폼 지원
     builder = builder.plugin(tauri_plugin_opener::init());
+
+    // global-shortcut 플러그인 — 전역 단축키 등록 (⌘⇧R)
+    builder = builder.plugin(tauri_plugin_global_shortcut::Builder::new().build());
 
     // NSPanel 플러그인 — 전체화면 앱 위에 표시되는 메뉴바 드롭다운 구현
     #[cfg(target_os = "macos")]
@@ -57,6 +61,30 @@ pub fn run() {
             #[cfg(target_os = "macos")]
             init_menubar_panel(app.handle(), &dropdown);
 
+            // 전역 단축키 ⌘⇧R → Reference 저장 팝업 열기
+            let shortcut_str = {
+                let state = app.state::<Mutex<AppState>>();
+                let pool = state.lock().unwrap().db_pool.clone();
+                let conn = pool.get().expect("DB 연결 실패");
+                services::settings::get_settings(&conn)
+                    .map(|s| s.shortcut_save_ref)
+                    .unwrap_or_else(|_| "CmdOrCtrl+Shift+R".to_string())
+            };
+            register_save_reference_shortcut(app.handle(), &shortcut_str);
+
+            // 설정 창 / Reference 팝업: X로 닫아도 숨기기만 함
+            for label in &["settings", "save-reference"] {
+                if let Some(win) = app.get_webview_window(label) {
+                    let w = win.clone();
+                    win.on_window_event(move |event| {
+                        if let tauri::WindowEvent::CloseRequested { api, .. } = event {
+                            api.prevent_close();
+                            let _ = w.hide();
+                        }
+                    });
+                }
+            }
+
             // 대시보드 창: X로 닫아도 파괴되지 않고 숨기기만 함
             // → 재오픈 시 get_webview_window("dashboard")가 항상 Some을 반환
             if let Some(dashboard) = app.get_webview_window("dashboard") {
@@ -70,8 +98,9 @@ pub fn run() {
             }
 
             // 트레이 우클릭 메뉴
+            let settings_item = MenuItem::with_id(app, "settings", "설정", true, None::<&str>)?;
             let quit_item = MenuItem::with_id(app, "quit", "focaro 종료", true, None::<&str>)?;
-            let tray_menu = Menu::with_items(app, &[&quit_item])?;
+            let tray_menu = Menu::with_items(app, &[&settings_item, &quit_item])?;
 
             // 트레이 클릭 핸들러
             let tray_app = app.handle().clone();
@@ -80,8 +109,15 @@ pub fn run() {
                 .menu(&tray_menu)
                 .show_menu_on_left_click(false)
                 .on_menu_event(|app, event| {
-                    if event.id() == "quit" {
-                        app.exit(0);
+                    match event.id().as_ref() {
+                        "quit" => app.exit(0),
+                        "settings" => {
+                            if let Some(win) = app.get_webview_window("settings") {
+                                let _ = win.show();
+                                let _ = win.set_focus();
+                            }
+                        }
+                        _ => {}
                     }
                 })
                 .on_tray_icon_event(move |tray, event| {
@@ -144,6 +180,13 @@ pub fn run() {
             commands::activity::get_top_sites,
             commands::activity::get_daily_focus_stats,
             commands::activity::get_session_events,
+            commands::settings::get_settings,
+            commands::settings::update_settings,
+            commands::settings::get_classification_rules,
+            commands::settings::add_classification_rule,
+            commands::settings::delete_classification_rule,
+            commands::settings::open_settings_window,
+            commands::settings::open_save_reference_window,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
@@ -251,6 +294,31 @@ fn request_accessibility_permission() {
             forKey: &*key
         ];
         AXIsProcessTrustedWithOptions(dict as *const std::ffi::c_void);
+    }
+}
+
+/// 전역 단축키 등록 (설정 변경 시 재호출)
+pub fn register_save_reference_shortcut(app: &tauri::AppHandle, shortcut_str: &str) {
+    // 기존 단축키 전체 해제 후 재등록
+    let _ = app.global_shortcut().unregister_all();
+
+    let Ok(shortcut) = shortcut_str.parse::<Shortcut>() else {
+        eprintln!("단축키 파싱 실패: {shortcut_str}");
+        return;
+    };
+
+    let app_handle = app.clone();
+    let result = app.global_shortcut().on_shortcut(shortcut, move |_app, _shortcut, event| {
+        if event.state == ShortcutState::Pressed {
+            if let Some(win) = app_handle.get_webview_window("save-reference") {
+                let _ = win.show();
+                let _ = win.set_focus();
+            }
+        }
+    });
+
+    if let Err(e) = result {
+        eprintln!("단축키 등록 실패: {e}");
     }
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -24,6 +24,9 @@ pub fn run() {
     // opener 플러그인 — URL/파일을 기본 앱으로 열기, 크로스플랫폼 지원
     builder = builder.plugin(tauri_plugin_opener::init());
 
+    // notification 플러그인 — macOS 알림
+    builder = builder.plugin(tauri_plugin_notification::init());
+
     // autostart 플러그인 — 로그인 시 자동 실행
     builder = builder.plugin(tauri_plugin_autostart::init(
         tauri_plugin_autostart::MacosLauncher::LaunchAgent,
@@ -224,6 +227,9 @@ pub fn run() {
             commands::settings::delete_classification_rule,
             commands::settings::open_settings_window,
             commands::settings::open_save_reference_window,
+            commands::goal::get_daily_goal,
+            commands::goal::set_daily_goal,
+            commands::goal::get_goal_progress,
             commands::onboarding::get_onboarding_status,
             commands::onboarding::complete_onboarding,
             commands::onboarding::apply_profession_rules,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -240,6 +240,10 @@ pub fn run() {
             commands::onboarding::delete_title_rule,
             commands::onboarding::override_activity_classification,
             commands::export::export_data,
+            commands::activity::get_tracked_apps,
+            commands::settings::get_app_rules,
+            commands::settings::add_app_rule,
+            commands::settings::delete_app_rule,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
@@ -256,9 +260,14 @@ fn init_menubar_panel(app_handle: &tauri::AppHandle, window: &WebviewWindow) {
 
     let panel = window.to_panel().unwrap();
 
-    // 메뉴바 레벨 바로 위 (25) — NSPopUpMenuWindowLevel(101)보다 낮아도
-    // NSPanel + NonActivatingPanel 조합이 전체화면 위에 뜨는 것을 보장
-    panel.set_level(NSMainMenuWindowLevel + 1);
+    // NSPopUpMenuWindowLevel(101) 바로 아래 — 일반 앱 창(0) 및 Floating(3),
+    // StatusWindow(25) 모두 위에 표시. makeKeyWindow 없이 orderFrontRegardless만 사용해
+    // NonActivatingPanel 충돌 없이 안정적으로 최상단에 표시
+    panel.set_level(NSMainMenuWindowLevel + 76); // = 100
+
+    // 시스템 창 그림자 비활성화 — CSS box-shadow로 직접 제어하여
+    // 창 크기 변경 시 이중 테두리(시스템 + CSS) 현상 방지
+    panel.set_has_shadow(false);
 
     // NonActivatingPanel: 패널이 키 윈도우가 되어도 앱이 활성화되지 않음
     // 다른 앱이 포커스를 잃지 않고 드롭다운만 표시됨
@@ -267,11 +276,9 @@ fn init_menubar_panel(app_handle: &tauri::AppHandle, window: &WebviewWindow) {
     panel.set_style_mask(NSWindowStyleMaskNonActivatingPanel);
 
     // CanJoinAllSpaces: 모든 스페이스(전체화면 포함)에 표시
-    // Stationary: 스페이스 전환 시 위치 유지
     // FullScreenAuxiliary: 전체화면 앱 위에 보조 창으로 표시 (핵심)
     panel.set_collection_behaviour(
         NSWindowCollectionBehavior::NSWindowCollectionBehaviorCanJoinAllSpaces
-            | NSWindowCollectionBehavior::NSWindowCollectionBehaviorStationary
             | NSWindowCollectionBehavior::NSWindowCollectionBehaviorFullScreenAuxiliary,
     );
 
@@ -321,7 +328,7 @@ fn toggle_panel(app_handle: &tauri::AppHandle, rect: Option<tauri::Rect>) {
                     let _ = w.set_position(tauri::LogicalPosition::new(x, y));
                 }
                 if let Ok(panel) = app.get_webview_panel("dropdown") {
-                    panel.show();
+                    panel.order_front_regardless();
                 }
             });
         }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -24,6 +24,12 @@ pub fn run() {
     // opener 플러그인 — URL/파일을 기본 앱으로 열기, 크로스플랫폼 지원
     builder = builder.plugin(tauri_plugin_opener::init());
 
+    // autostart 플러그인 — 로그인 시 자동 실행
+    builder = builder.plugin(tauri_plugin_autostart::init(
+        tauri_plugin_autostart::MacosLauncher::LaunchAgent,
+        None,
+    ));
+
     // global-shortcut 플러그인 — 전역 단축키 등록 (⌘⇧R)
     builder = builder.plugin(tauri_plugin_global_shortcut::Builder::new().build());
 
@@ -79,16 +85,28 @@ pub fn run() {
             #[cfg(target_os = "macos")]
             init_menubar_panel(app.handle(), &dropdown);
 
-            // 전역 단축키 ⌘⇧R → Reference 저장 팝업 열기
-            let shortcut_str = {
+            // 전역 단축키 등록 (⌘⇧R, ⌘⇧S, ⌘⇧E)
+            {
                 let state = app.state::<Mutex<AppState>>();
                 let pool = state.lock().unwrap().db_pool.clone();
                 let conn = pool.get().expect("DB 연결 실패");
-                services::settings::get_settings(&conn)
-                    .map(|s| s.shortcut_save_ref)
-                    .unwrap_or_else(|_| "CmdOrCtrl+Shift+R".to_string())
-            };
-            register_save_reference_shortcut(app.handle(), &shortcut_str);
+                let settings = services::settings::get_settings(&conn)
+                    .unwrap_or_default();
+                register_all_shortcuts(app.handle(), &settings);
+            }
+
+            // 온보딩 완료 여부 체크 — 미완료 시 온보딩 창 표시
+            {
+                let state = app.state::<Mutex<AppState>>();
+                let pool = state.lock().unwrap().db_pool.clone();
+                let conn = pool.get().expect("DB 연결 실패");
+                if !services::onboarding::is_onboarding_completed(&conn) {
+                    if let Some(win) = app.get_webview_window("onboarding") {
+                        let _ = win.show();
+                        let _ = win.set_focus();
+                    }
+                }
+            }
 
             // 설정 창 / Reference 팝업: X로 닫아도 숨기기만 함
             for label in &["settings", "save-reference"] {
@@ -206,6 +224,13 @@ pub fn run() {
             commands::settings::delete_classification_rule,
             commands::settings::open_settings_window,
             commands::settings::open_save_reference_window,
+            commands::onboarding::get_onboarding_status,
+            commands::onboarding::complete_onboarding,
+            commands::onboarding::apply_profession_rules,
+            commands::onboarding::get_title_rules,
+            commands::onboarding::add_title_rule,
+            commands::onboarding::delete_title_rule,
+            commands::onboarding::override_activity_classification,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
@@ -316,28 +341,60 @@ fn request_accessibility_permission() {
     }
 }
 
-/// 전역 단축키 등록 (설정 변경 시 재호출)
-pub fn register_save_reference_shortcut(app: &tauri::AppHandle, shortcut_str: &str) {
+/// 전역 단축키 전체 등록 (설정 변경 시 재호출)
+pub fn register_all_shortcuts(app: &tauri::AppHandle, settings: &models::settings::AppSettings) {
     // 기존 단축키 전체 해제 후 재등록
     let _ = app.global_shortcut().unregister_all();
 
-    let Ok(shortcut) = shortcut_str.parse::<Shortcut>() else {
-        eprintln!("단축키 파싱 실패: {shortcut_str}");
-        return;
-    };
-
-    let app_handle = app.clone();
-    let result = app.global_shortcut().on_shortcut(shortcut, move |_app, _shortcut, event| {
-        if event.state == ShortcutState::Pressed {
-            if let Some(win) = app_handle.get_webview_window("save-reference") {
-                let _ = win.show();
-                let _ = win.set_focus();
+    register_shortcut(app, &settings.shortcut_save_ref, {
+        let app = app.clone();
+        move |event: &tauri_plugin_global_shortcut::ShortcutEvent| {
+            if event.state == ShortcutState::Pressed {
+                if let Some(win) = app.get_webview_window("save-reference") {
+                    let _ = win.show();
+                    let _ = win.set_focus();
+                }
             }
         }
     });
 
-    if let Err(e) = result {
-        eprintln!("단축키 등록 실패: {e}");
+    // 세션 시작 단축키
+    let app_start = app.clone();
+    register_shortcut(app, &settings.shortcut_session_start, move |event| {
+        if event.state == ShortcutState::Pressed {
+            let app = app_start.clone();
+            tauri::async_runtime::spawn(async move {
+                let state = app.state::<std::sync::Mutex<state::app_state::AppState>>();
+                let _ = commands::session::start_session(state, app.clone()).await;
+            });
+        }
+    });
+
+    // 세션 종료 단축키
+    let app_end = app.clone();
+    register_shortcut(app, &settings.shortcut_session_end, move |event| {
+        if event.state == ShortcutState::Pressed {
+            let app = app_end.clone();
+            tauri::async_runtime::spawn(async move {
+                let state = app.state::<std::sync::Mutex<state::app_state::AppState>>();
+                let _ = commands::session::end_session(state).await;
+            });
+        }
+    });
+}
+
+fn register_shortcut<F>(app: &tauri::AppHandle, shortcut_str: &str, handler: F)
+where
+    F: Fn(&tauri_plugin_global_shortcut::ShortcutEvent) + Send + Sync + 'static,
+{
+    let Ok(shortcut) = shortcut_str.parse::<Shortcut>() else {
+        eprintln!("단축키 파싱 실패: {shortcut_str}");
+        return;
+    };
+    if let Err(e) = app.global_shortcut().on_shortcut(shortcut, move |_app, _shortcut, event| {
+        handler(&event);
+    }) {
+        eprintln!("단축키 등록 실패 ({shortcut_str}): {e}");
     }
 }
 
@@ -368,5 +425,20 @@ fn compute_tray_title(pool: &services::db::DbPool, session_id: &str) -> Option<S
         format!("{:02}:{:02}", minutes, seconds)
     };
 
-    Some(format!("🟢 {}", time_str))
+    // 최근 활동의 classification으로 아이콘 결정
+    let icon = conn
+        .query_row(
+            "SELECT classification FROM activities WHERE session_id = ?1 ORDER BY started_at DESC LIMIT 1",
+            rusqlite::params![session_id],
+            |r| r.get::<_, String>(0),
+        )
+        .ok()
+        .map(|cls| match cls.as_str() {
+            "Focus" => "🟢",
+            "Distraction" => "🔴",
+            _ => "🟡",
+        })
+        .unwrap_or("🟢");
+
+    Some(format!("{} {}", icon, time_str))
 }

--- a/src-tauri/src/models/goal.rs
+++ b/src-tauri/src/models/goal.rs
@@ -1,0 +1,39 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct DailyGoal {
+    pub date: String,       // YYYY-MM-DD
+    pub target_secs: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GoalProgress {
+    pub date: String,
+    pub target_secs: i64,
+    pub actual_focus_secs: i64,
+    pub progress_pct: f64,  // 0.0 ~ 100.0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_daily_goal_serde() {
+        let g = DailyGoal { date: "2026-03-25".to_string(), target_secs: 7200 };
+        let json = serde_json::to_string(&g).unwrap();
+        let decoded: DailyGoal = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded, g);
+    }
+
+    #[test]
+    fn test_goal_progress_pct_calculation() {
+        let p = GoalProgress {
+            date: "2026-03-25".to_string(),
+            target_secs: 7200,
+            actual_focus_secs: 3600,
+            progress_pct: 50.0,
+        };
+        assert!((p.progress_pct - 50.0).abs() < f64::EPSILON);
+    }
+}

--- a/src-tauri/src/models/mod.rs
+++ b/src-tauri/src/models/mod.rs
@@ -1,5 +1,6 @@
 pub mod activity;
 pub mod archive;
+pub mod goal;
 pub mod metrics;
 pub mod onboarding;
 pub mod reference;

--- a/src-tauri/src/models/mod.rs
+++ b/src-tauri/src/models/mod.rs
@@ -1,6 +1,7 @@
 pub mod activity;
 pub mod archive;
 pub mod metrics;
+pub mod onboarding;
 pub mod reference;
 pub mod session;
 pub mod settings;

--- a/src-tauri/src/models/onboarding.rs
+++ b/src-tauri/src/models/onboarding.rs
@@ -1,0 +1,90 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct TitleRule {
+    pub id: i64,
+    pub domain: String,
+    pub keyword: String,
+    pub category: String,
+}
+
+/// 온보딩에서 선택 가능한 직업 유형
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum Profession {
+    Developer,
+    Designer,
+    Marketer,
+    Student,
+    Other,
+}
+
+/// 직업별 사전 설정 규칙
+pub fn profession_domain_rules(profession: &Profession) -> Vec<(&'static str, &'static str)> {
+    match profession {
+        Profession::Developer => vec![
+            ("iterm2.com", "Focus"),
+            ("localhost", "Focus"),
+            ("127.0.0.1", "Focus"),
+            ("npmjs.com", "Focus"),
+            ("crates.io", "Focus"),
+            ("rust-lang.org", "Focus"),
+            ("reactjs.org", "Focus"),
+            ("developer.mozilla.org", "Focus"),
+        ],
+        Profession::Designer => vec![
+            ("dribbble.com", "Focus"),
+            ("behance.net", "Focus"),
+            ("awwwards.com", "Focus"),
+            ("fonts.google.com", "Focus"),
+            ("coolors.co", "Focus"),
+            ("unsplash.com", "Focus"),
+        ],
+        Profession::Marketer => vec![
+            ("analytics.google.com", "Focus"),
+            ("ads.google.com", "Focus"),
+            ("mailchimp.com", "Focus"),
+            ("hubspot.com", "Focus"),
+            ("semrush.com", "Focus"),
+        ],
+        Profession::Student => vec![
+            ("coursera.org", "Focus"),
+            ("udemy.com", "Focus"),
+            ("khanacademy.org", "Focus"),
+            ("edx.org", "Focus"),
+            ("wikipedia.org", "Focus"),
+        ],
+        Profession::Other => vec![],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_developer_rules_not_empty() {
+        let rules = profession_domain_rules(&Profession::Developer);
+        assert!(!rules.is_empty());
+        assert!(rules.iter().any(|(d, _)| *d == "localhost"));
+    }
+
+    #[test]
+    fn test_other_profession_empty_rules() {
+        let rules = profession_domain_rules(&Profession::Other);
+        assert!(rules.is_empty());
+    }
+
+    #[test]
+    fn test_title_rule_serde() {
+        let r = TitleRule {
+            id: 1,
+            domain: "youtube.com".to_string(),
+            keyword: "tutorial".to_string(),
+            category: "Focus".to_string(),
+        };
+        let json = serde_json::to_string(&r).unwrap();
+        let decoded: TitleRule = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded, r);
+    }
+}

--- a/src-tauri/src/models/reference.rs
+++ b/src-tauri/src/models/reference.rs
@@ -17,6 +17,13 @@ pub struct SaveReferenceInput {
     pub tags: Option<Vec<String>>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UpdateReferenceInput {
+    pub id: String,
+    pub title: String,
+    pub tags: Vec<String>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src-tauri/src/models/settings.rs
+++ b/src-tauri/src/models/settings.rs
@@ -4,6 +4,8 @@ use serde::{Deserialize, Serialize};
 pub struct AppSettings {
     pub retention_days: i64,
     pub shortcut_save_ref: String,
+    pub shortcut_session_start: String,
+    pub shortcut_session_end: String,
 }
 
 impl Default for AppSettings {
@@ -11,6 +13,8 @@ impl Default for AppSettings {
         Self {
             retention_days: 30,
             shortcut_save_ref: "CmdOrCtrl+Shift+R".to_string(),
+            shortcut_session_start: "CmdOrCtrl+Shift+S".to_string(),
+            shortcut_session_end: "CmdOrCtrl+Shift+E".to_string(),
         }
     }
 }
@@ -37,11 +41,14 @@ mod tests {
     fn test_app_settings_serde_roundtrip() {
         let s = AppSettings {
             retention_days: 60,
-            shortcut_save_ref: "CmdOrCtrl+Shift+S".to_string(),
+            shortcut_save_ref: "CmdOrCtrl+Shift+R".to_string(),
+            shortcut_session_start: "CmdOrCtrl+Shift+S".to_string(),
+            shortcut_session_end: "CmdOrCtrl+Shift+E".to_string(),
         };
         let json = serde_json::to_string(&s).unwrap();
         let decoded: AppSettings = serde_json::from_str(&json).unwrap();
         assert_eq!(decoded.retention_days, 60);
-        assert_eq!(decoded.shortcut_save_ref, "CmdOrCtrl+Shift+S");
+        assert_eq!(decoded.shortcut_save_ref, "CmdOrCtrl+Shift+R");
+        assert_eq!(decoded.shortcut_session_start, "CmdOrCtrl+Shift+S");
     }
 }

--- a/src-tauri/src/models/settings.rs
+++ b/src-tauri/src/models/settings.rs
@@ -2,13 +2,24 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AppSettings {
-    pub retention_days: u32,
+    pub retention_days: i64,
+    pub shortcut_save_ref: String,
 }
 
 impl Default for AppSettings {
     fn default() -> Self {
-        Self { retention_days: 30 }
+        Self {
+            retention_days: 30,
+            shortcut_save_ref: "CmdOrCtrl+Shift+R".to_string(),
+        }
     }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ClassificationRule {
+    pub id: i64,
+    pub domain: String,
+    pub category: String,
 }
 
 #[cfg(test)]
@@ -17,15 +28,20 @@ mod tests {
 
     #[test]
     fn test_app_settings_default() {
-        let settings = AppSettings::default();
-        assert_eq!(settings.retention_days, 30);
+        let s = AppSettings::default();
+        assert_eq!(s.retention_days, 30);
+        assert_eq!(s.shortcut_save_ref, "CmdOrCtrl+Shift+R");
     }
 
     #[test]
     fn test_app_settings_serde_roundtrip() {
-        let settings = AppSettings { retention_days: 60 };
-        let json = serde_json::to_string(&settings).unwrap();
+        let s = AppSettings {
+            retention_days: 60,
+            shortcut_save_ref: "CmdOrCtrl+Shift+S".to_string(),
+        };
+        let json = serde_json::to_string(&s).unwrap();
         let decoded: AppSettings = serde_json::from_str(&json).unwrap();
         assert_eq!(decoded.retention_days, 60);
+        assert_eq!(decoded.shortcut_save_ref, "CmdOrCtrl+Shift+S");
     }
 }

--- a/src-tauri/src/services/activity.rs
+++ b/src-tauri/src/services/activity.rs
@@ -184,3 +184,75 @@ pub fn query_daily_focus_stats(pool: &DbPool, date: &str) -> Result<DailyFocusSt
     let total_secs = focus_secs + neutral_secs + distraction_secs;
     Ok(DailyFocusStats { total_secs, focus_secs, neutral_secs, distraction_secs })
 }
+
+pub struct WeeklyDayStat {
+    pub date: String,       // YYYY-MM-DD
+    pub focus_secs: i64,
+    pub total_secs: i64,
+}
+
+/// 특정 주(월~일)의 요일별 집중 통계 조회
+/// start_date: 해당 주 월요일 (YYYY-MM-DD)
+pub fn query_weekly_report(pool: &DbPool, start_date: &str) -> Result<Vec<WeeklyDayStat>, AppError> {
+    let conn = pool.get().map_err(AppError::from)?;
+    let mut stmt = conn.prepare(
+        "SELECT date(s.started_at, 'unixepoch') as day,
+                SUM(CASE WHEN a.classification = 'Focus' THEN a.duration_secs ELSE 0 END) as focus_secs,
+                SUM(a.duration_secs) as total_secs
+         FROM activities a
+         JOIN sessions s ON a.session_id = s.id
+         WHERE day >= ?1 AND day < date(?1, '+7 days')
+           AND a.duration_secs IS NOT NULL
+         GROUP BY day
+         ORDER BY day ASC"
+    ).map_err(AppError::from)?;
+
+    let rows = stmt.query_map(rusqlite::params![start_date], |r| {
+        Ok(WeeklyDayStat {
+            date: r.get(0)?,
+            focus_secs: r.get(1)?,
+            total_secs: r.get(2)?,
+        })
+    })
+    .map_err(AppError::from)?
+    .filter_map(|r| r.ok())
+    .collect();
+
+    Ok(rows)
+}
+
+pub struct TrendPoint {
+    pub date: String,
+    pub focus_pct: f64,
+    pub focus_secs: i64,
+}
+
+/// 최근 N일간 일별 집중도 트렌드
+pub fn query_trend(pool: &DbPool, days: i64) -> Result<Vec<TrendPoint>, AppError> {
+    let conn = pool.get().map_err(AppError::from)?;
+    let mut stmt = conn.prepare(
+        "SELECT date(s.started_at, 'unixepoch') as day,
+                CAST(SUM(CASE WHEN a.classification = 'Focus' THEN a.duration_secs ELSE 0 END) AS REAL)
+                  / NULLIF(SUM(a.duration_secs), 0) * 100.0 as focus_pct,
+                SUM(CASE WHEN a.classification = 'Focus' THEN a.duration_secs ELSE 0 END) as focus_secs
+         FROM activities a
+         JOIN sessions s ON a.session_id = s.id
+         WHERE day >= date('now', '-' || ?1 || ' days')
+           AND a.duration_secs IS NOT NULL
+         GROUP BY day
+         ORDER BY day ASC"
+    ).map_err(AppError::from)?;
+
+    let rows = stmt.query_map(rusqlite::params![days], |r| {
+        Ok(TrendPoint {
+            date: r.get(0)?,
+            focus_pct: r.get::<_, Option<f64>>(1)?.unwrap_or(0.0),
+            focus_secs: r.get(2)?,
+        })
+    })
+    .map_err(AppError::from)?
+    .filter_map(|r| r.ok())
+    .collect();
+
+    Ok(rows)
+}

--- a/src-tauri/src/services/activity.rs
+++ b/src-tauri/src/services/activity.rs
@@ -256,3 +256,43 @@ pub fn query_trend(pool: &DbPool, days: i64) -> Result<Vec<TrendPoint>, AppError
 
     Ok(rows)
 }
+
+/// 날짜 범위 활동 내보내기용 전체 조회
+pub fn query_export_activities(
+    pool: &DbPool,
+    start_date: &str,
+    end_date: &str,
+) -> Result<Vec<ActivityRow>, AppError> {
+    let conn = pool.get().map_err(AppError::from)?;
+    let mut stmt = conn
+        .prepare(
+            "SELECT id, session_id, app_name, url, domain, classification, started_at, duration_secs, title
+             FROM activities
+             WHERE date(started_at, 'unixepoch') >= ?1
+               AND date(started_at, 'unixepoch') <= ?2
+               AND duration_secs IS NOT NULL
+             ORDER BY started_at ASC",
+        )
+        .map_err(AppError::from)?;
+
+    let rows = stmt
+        .query_map(rusqlite::params![start_date, end_date], |r| {
+            let ts: i64 = r.get(6)?;
+            Ok(ActivityRow {
+                id: r.get(0)?,
+                session_id: r.get(1)?,
+                app_name: r.get(2)?,
+                url: r.get(3)?,
+                domain: r.get(4)?,
+                title: r.get(8)?,
+                classification: r.get(5)?,
+                started_at: unix_to_iso(ts),
+                duration_secs: r.get(7)?,
+            })
+        })
+        .map_err(AppError::from)?
+        .filter_map(|r| r.ok())
+        .collect();
+
+    Ok(rows)
+}

--- a/src-tauri/src/services/activity.rs
+++ b/src-tauri/src/services/activity.rs
@@ -1,0 +1,186 @@
+use crate::errors::AppError;
+use crate::services::db::DbPool;
+use crate::services::session::unix_to_iso;
+
+pub struct ActivityRow {
+    pub id: String,
+    pub session_id: String,
+    pub app_name: String,
+    pub url: Option<String>,
+    pub domain: Option<String>,
+    pub title: Option<String>,
+    pub classification: String,
+    pub started_at: String, // ISO
+    pub duration_secs: Option<i64>,
+}
+
+pub struct SessionEvent {
+    pub session_id: String,
+    pub event_type: String, // "start" | "end"
+    pub timestamp: String,  // ISO
+}
+
+pub struct DomainStat {
+    pub domain: String,
+    pub total_secs: i64,
+    pub classification: String,
+}
+
+pub struct DailyFocusStats {
+    pub total_secs: i64,
+    pub focus_secs: i64,
+    pub neutral_secs: i64,
+    pub distraction_secs: i64,
+}
+
+/// 특정 날짜(UTC)의 활동 타임라인 조회 (최신순)
+pub fn query_activity_timeline(pool: &DbPool, date: &str) -> Result<Vec<ActivityRow>, AppError> {
+    let conn = pool.get().map_err(AppError::from)?;
+    let mut stmt = conn
+        .prepare(
+            "SELECT id, session_id, app_name, url, domain, classification, started_at, duration_secs, title
+             FROM activities
+             WHERE date(started_at, 'unixepoch') = ?1
+             ORDER BY started_at DESC",
+        )
+        .map_err(AppError::from)?;
+
+    let rows = stmt
+        .query_map(rusqlite::params![date], |r| {
+            let ts: i64 = r.get(6)?;
+            Ok(ActivityRow {
+                id: r.get(0)?,
+                session_id: r.get(1)?,
+                app_name: r.get(2)?,
+                url: r.get(3)?,
+                domain: r.get(4)?,
+                classification: r.get(5)?,
+                started_at: unix_to_iso(ts),
+                duration_secs: r.get(7)?,
+                title: r.get(8)?,
+            })
+        })
+        .map_err(AppError::from)?;
+
+    let mut result = Vec::new();
+    for row in rows {
+        result.push(row.map_err(AppError::from)?);
+    }
+    Ok(result)
+}
+
+/// 특정 날짜(UTC)의 세션 시작/종료 이벤트 조회
+pub fn query_session_events(pool: &DbPool, date: &str) -> Result<Vec<SessionEvent>, AppError> {
+    let conn = pool.get().map_err(AppError::from)?;
+    let mut stmt = conn
+        .prepare(
+            "SELECT id, started_at, ended_at, is_complete
+             FROM sessions
+             WHERE date(started_at, 'unixepoch') = ?1
+                OR (ended_at IS NOT NULL AND date(ended_at, 'unixepoch') = ?1)
+             ORDER BY started_at ASC",
+        )
+        .map_err(AppError::from)?;
+
+    let rows = stmt
+        .query_map(rusqlite::params![date], |r| {
+            let id: String = r.get(0)?;
+            let started_at: i64 = r.get(1)?;
+            let ended_at: Option<i64> = r.get(2)?;
+            let is_complete: i64 = r.get(3)?;
+            Ok((id, started_at, ended_at, is_complete))
+        })
+        .map_err(AppError::from)?;
+
+    let mut events = Vec::new();
+    for row in rows {
+        let (id, started_at, ended_at, is_complete) = row.map_err(AppError::from)?;
+        events.push(SessionEvent {
+            session_id: id.clone(),
+            event_type: "start".to_string(),
+            timestamp: unix_to_iso(started_at),
+        });
+        if let Some(ended) = ended_at {
+            let event_type = if is_complete == 1 { "end" } else { "end_incomplete" };
+            events.push(SessionEvent {
+                session_id: id,
+                event_type: event_type.to_string(),
+                timestamp: unix_to_iso(ended),
+            });
+        }
+    }
+    Ok(events)
+}
+
+/// 특정 날짜(UTC)의 도메인별 누적 시간 (domain이 NULL인 항목 제외, 내림차순)
+pub fn query_top_sites(pool: &DbPool, date: &str, limit: u32) -> Result<Vec<DomainStat>, AppError> {
+    let conn = pool.get().map_err(AppError::from)?;
+    let mut stmt = conn
+        .prepare(
+            "SELECT domain,
+                    SUM(duration_secs) as total,
+                    (SELECT classification FROM activities a2
+                     WHERE a2.domain = a.domain
+                       AND date(a2.started_at, 'unixepoch') = ?1
+                     ORDER BY a2.started_at DESC LIMIT 1) as cls
+             FROM activities a
+             WHERE date(started_at, 'unixepoch') = ?1
+               AND domain IS NOT NULL
+             GROUP BY domain
+             ORDER BY total DESC
+             LIMIT ?2",
+        )
+        .map_err(AppError::from)?;
+
+    let rows = stmt
+        .query_map(rusqlite::params![date, limit], |r| {
+            Ok(DomainStat {
+                domain: r.get(0)?,
+                total_secs: r.get(1)?,
+                classification: r.get::<_, Option<String>>(2)?.unwrap_or_else(|| "Neutral".to_string()),
+            })
+        })
+        .map_err(AppError::from)?;
+
+    let mut result = Vec::new();
+    for row in rows {
+        result.push(row.map_err(AppError::from)?);
+    }
+    Ok(result)
+}
+
+/// 특정 날짜(UTC)의 Focus/Neutral/Distraction 누적 통계
+pub fn query_daily_focus_stats(pool: &DbPool, date: &str) -> Result<DailyFocusStats, AppError> {
+    let conn = pool.get().map_err(AppError::from)?;
+    let mut stmt = conn
+        .prepare(
+            "SELECT classification, COALESCE(SUM(duration_secs), 0)
+             FROM activities
+             WHERE date(started_at, 'unixepoch') = ?1
+             GROUP BY classification",
+        )
+        .map_err(AppError::from)?;
+
+    let rows = stmt
+        .query_map(rusqlite::params![date], |r| {
+            Ok((r.get::<_, String>(0)?, r.get::<_, i64>(1)?))
+        })
+        .map_err(AppError::from)?;
+
+    let mut focus_secs = 0i64;
+    let mut neutral_secs = 0i64;
+    let mut distraction_secs = 0i64;
+
+    for row in rows {
+        let (cls, secs) = row.map_err(AppError::from)?;
+        match cls.as_str() {
+            "Focus" => focus_secs = secs,
+            "Neutral" => neutral_secs = secs,
+            "Distraction" => distraction_secs = secs,
+            _ => {}
+        }
+    }
+
+    let total_secs = focus_secs + neutral_secs + distraction_secs;
+    Ok(DailyFocusStats { total_secs, focus_secs, neutral_secs, distraction_secs })
+}

--- a/src-tauri/src/services/archive.rs
+++ b/src-tauri/src/services/archive.rs
@@ -1,0 +1,98 @@
+use crate::errors::AppError;
+use crate::services::db::DbPool;
+
+/// 보관 기간이 지난 Activity를 일별 집계(ArchivedDailySummary)로 변환 후 원본 삭제
+/// cutoff 이전 날짜의 활동을 대상으로 함
+pub fn archive_old_data(pool: &DbPool, retention_days: i64) -> Result<(), AppError> {
+    let conn = pool.get().map_err(AppError::from)?;
+
+    // cutoff 날짜: 오늘 - retention_days
+    let cutoff_unix = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs() as i64
+        - retention_days * 86400;
+
+    // 아카이브할 날짜 목록 조회 (보관 기간 초과)
+    let dates: Vec<String> = {
+        let mut stmt = conn
+            .prepare(
+                "SELECT DISTINCT date(started_at, 'unixepoch') as d
+                 FROM activities
+                 WHERE started_at < ?1
+                 ORDER BY d",
+            )
+            .map_err(AppError::from)?;
+
+        let rows = stmt
+            .query_map(rusqlite::params![cutoff_unix], |r| r.get(0))
+            .map_err(AppError::from)?
+            .filter_map(|r| r.ok())
+            .collect::<Vec<_>>();
+        rows
+    };
+
+    for date in &dates {
+        // 해당 날짜의 집계
+        let (total, focus, neutral, distraction): (i64, i64, i64, i64) = conn
+            .query_row(
+                "SELECT
+                    COALESCE(SUM(duration_secs), 0),
+                    COALESCE(SUM(CASE WHEN classification='Focus' THEN duration_secs ELSE 0 END), 0),
+                    COALESCE(SUM(CASE WHEN classification='Neutral' THEN duration_secs ELSE 0 END), 0),
+                    COALESCE(SUM(CASE WHEN classification='Distraction' THEN duration_secs ELSE 0 END), 0)
+                 FROM activities
+                 WHERE date(started_at, 'unixepoch') = ?1",
+                rusqlite::params![date],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?)),
+            )
+            .map_err(AppError::from)?;
+
+        // 상위 도메인 JSON 직렬화
+        let top_domains: Vec<(String, i64)> = {
+            let mut stmt = conn
+                .prepare(
+                    "SELECT domain, SUM(duration_secs) as t
+                     FROM activities
+                     WHERE date(started_at, 'unixepoch') = ?1 AND domain IS NOT NULL
+                     GROUP BY domain ORDER BY t DESC LIMIT 5",
+                )
+                .map_err(AppError::from)?;
+
+            let rows = stmt
+                .query_map(rusqlite::params![date], |r| {
+                    Ok((r.get::<_, String>(0)?, r.get::<_, i64>(1)?))
+                })
+                .map_err(AppError::from)?
+                .filter_map(|r| r.ok())
+                .collect::<Vec<_>>();
+            rows
+        };
+
+        let top_json = serde_json::to_string(&top_domains).unwrap_or_else(|_| "[]".to_string());
+
+        // 아카이브 삽입 또는 갱신
+        conn.execute(
+            "INSERT INTO archived_daily_summaries
+                (date, total_secs, focus_secs, neutral_secs, distraction_secs, top_domains_json)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+             ON CONFLICT(date) DO UPDATE SET
+                total_secs=excluded.total_secs,
+                focus_secs=excluded.focus_secs,
+                neutral_secs=excluded.neutral_secs,
+                distraction_secs=excluded.distraction_secs,
+                top_domains_json=excluded.top_domains_json",
+            rusqlite::params![date, total, focus, neutral, distraction, top_json],
+        )
+        .map_err(AppError::from)?;
+
+        // 원본 활동 삭제
+        conn.execute(
+            "DELETE FROM activities WHERE date(started_at, 'unixepoch') = ?1",
+            rusqlite::params![date],
+        )
+        .map_err(AppError::from)?;
+    }
+
+    Ok(())
+}

--- a/src-tauri/src/services/browser.rs
+++ b/src-tauri/src/services/browser.rs
@@ -31,6 +31,37 @@ pub fn get_browser_url(app_name: &str) -> Option<String> {
     }
 }
 
+/// 현재 활성 브라우저 탭의 페이지 타이틀 반환.
+/// Automation 권한 없거나 실패 시 None 반환.
+pub fn get_browser_title(app_name: &str) -> Option<String> {
+    let script = match app_name {
+        "Google Chrome" => {
+            r#"tell application "Google Chrome" to get title of active tab of front window"#
+        }
+        "Safari" => {
+            r#"tell application "Safari" to get name of current tab of front window"#
+        }
+        _ => return None,
+    };
+
+    let output = Command::new("osascript")
+        .arg("-e")
+        .arg(script)
+        .output()
+        .ok()?;
+
+    if output.status.success() {
+        let title = String::from_utf8(output.stdout).ok()?.trim().to_string();
+        if title.is_empty() {
+            None
+        } else {
+            Some(title)
+        }
+    } else {
+        None
+    }
+}
+
 /// URL에서 도메인 추출 (scheme, path 제거)
 pub fn extract_domain(url: &str) -> Option<String> {
     let without_scheme = url

--- a/src-tauri/src/services/browser.rs
+++ b/src-tauri/src/services/browser.rs
@@ -27,6 +27,11 @@ pub fn get_browser_url(app_name: &str) -> Option<String> {
             Some(url)
         }
     } else {
+        // Automation 권한 거부 또는 브라우저 창 없음 → url=null로 처리
+        if !output.stderr.is_empty() {
+            let err = String::from_utf8_lossy(&output.stderr);
+            eprintln!("[browser] URL 조회 실패 (url=null): {}", err.trim());
+        }
         None
     }
 }

--- a/src-tauri/src/services/classifier.rs
+++ b/src-tauri/src/services/classifier.rs
@@ -1,22 +1,39 @@
 use crate::models::activity::Classification;
 
-/// domain 기반 규칙 매칭으로 Classification 반환.
-/// rules: (domain, category) 튜플 슬라이스 (DB 조회 결과)
-/// rules가 비어 있으면 내장 기본 규칙 사용.
-/// 매칭 없으면 Neutral 반환.
-pub fn classify(domain: Option<&str>, rules: &[(String, String)]) -> Classification {
+/// 활동 분류.
+/// 우선순위: title_rules (domain+keyword) > domain_rules (domain) > 내장 기본 규칙 > Neutral
+///
+/// - domain_rules: (domain, category) — DB classification_rules 테이블
+/// - title_rules: (domain, keyword, category) — DB title_rules 테이블
+/// - title: 현재 브라우저 탭 타이틀 (keyword 매칭에 사용)
+pub fn classify(
+    domain: Option<&str>,
+    title: Option<&str>,
+    domain_rules: &[(String, String)],
+    title_rules: &[(String, String, String)],
+) -> Classification {
     let Some(d) = domain else {
         return Classification::Neutral;
     };
 
-    // 사용자 정의 규칙 우선 검색
-    for (rule_domain, category) in rules {
+    // 1순위: title_rules (domain + keyword 매칭, 대소문자 무시)
+    if let Some(t) = title {
+        let t_lower = t.to_lowercase();
+        for (rule_domain, keyword, category) in title_rules {
+            if rule_domain == d && t_lower.contains(&keyword.to_lowercase()) {
+                return parse_category(category);
+            }
+        }
+    }
+
+    // 2순위: 사용자 정의 domain_rules
+    for (rule_domain, category) in domain_rules {
         if rule_domain == d {
             return parse_category(category);
         }
     }
 
-    // 내장 기본 규칙
+    // 3순위: 내장 기본 규칙
     match d {
         "github.com" | "stackoverflow.com" | "docs.rs" | "developer.apple.com"
         | "figma.com" | "notion.so" | "linear.app" => Classification::Focus,
@@ -41,39 +58,125 @@ mod tests {
     use super::classify;
     use crate::models::activity::Classification;
 
+    // 기존 테스트 — 새 시그니처에 맞게 빈 슬라이스 전달
     #[test]
     fn test_github_classified_as_focus() {
-        assert_eq!(classify(Some("github.com"), &[]), Classification::Focus);
+        assert_eq!(classify(Some("github.com"), None, &[], &[]), Classification::Focus);
     }
 
     #[test]
     fn test_stackoverflow_classified_as_focus() {
-        assert_eq!(classify(Some("stackoverflow.com"), &[]), Classification::Focus);
+        assert_eq!(classify(Some("stackoverflow.com"), None, &[], &[]), Classification::Focus);
     }
 
     #[test]
     fn test_youtube_classified_as_distraction() {
-        assert_eq!(classify(Some("youtube.com"), &[]), Classification::Distraction);
+        assert_eq!(classify(Some("youtube.com"), None, &[], &[]), Classification::Distraction);
     }
 
     #[test]
     fn test_twitter_classified_as_distraction() {
-        assert_eq!(classify(Some("twitter.com"), &[]), Classification::Distraction);
+        assert_eq!(classify(Some("twitter.com"), None, &[], &[]), Classification::Distraction);
     }
 
     #[test]
     fn test_unknown_domain_classified_as_neutral() {
-        assert_eq!(classify(Some("example.com"), &[]), Classification::Neutral);
+        assert_eq!(classify(Some("example.com"), None, &[], &[]), Classification::Neutral);
     }
 
     #[test]
     fn test_none_domain_classified_as_neutral() {
-        assert_eq!(classify(None, &[]), Classification::Neutral);
+        assert_eq!(classify(None, None, &[], &[]), Classification::Neutral);
     }
 
     #[test]
-    fn test_custom_rule_overrides_default() {
+    fn test_custom_domain_rule_overrides_default() {
         let rules = vec![("example.com".to_string(), "Focus".to_string())];
-        assert_eq!(classify(Some("example.com"), &rules), Classification::Focus);
+        assert_eq!(classify(Some("example.com"), None, &rules, &[]), Classification::Focus);
+    }
+
+    // title_rules 테스트
+    #[test]
+    fn test_title_rule_overrides_domain_distraction() {
+        // youtube.com은 기본 Distraction이지만 title에 "tutorial"이 있으면 Focus
+        let title_rules = vec![(
+            "youtube.com".to_string(),
+            "tutorial".to_string(),
+            "Focus".to_string(),
+        )];
+        assert_eq!(
+            classify(Some("youtube.com"), Some("Rust Tutorial 2024"), &[], &title_rules),
+            Classification::Focus
+        );
+    }
+
+    #[test]
+    fn test_title_rule_keyword_case_insensitive() {
+        let title_rules = vec![(
+            "youtube.com".to_string(),
+            "tutorial".to_string(),
+            "Focus".to_string(),
+        )];
+        assert_eq!(
+            classify(Some("youtube.com"), Some("TUTORIAL React"), &[], &title_rules),
+            Classification::Focus
+        );
+    }
+
+    #[test]
+    fn test_title_rule_no_match_falls_through_to_default() {
+        let title_rules = vec![(
+            "youtube.com".to_string(),
+            "tutorial".to_string(),
+            "Focus".to_string(),
+        )];
+        // 타이틀에 keyword 없으면 기본 Distraction
+        assert_eq!(
+            classify(Some("youtube.com"), Some("Music MV"), &[], &title_rules),
+            Classification::Distraction
+        );
+    }
+
+    #[test]
+    fn test_title_rule_wrong_domain_no_effect() {
+        let title_rules = vec![(
+            "instagram.com".to_string(),
+            "tutorial".to_string(),
+            "Focus".to_string(),
+        )];
+        // domain이 다르면 title_rule 무시, youtube.com 기본 규칙 적용
+        assert_eq!(
+            classify(Some("youtube.com"), Some("tutorial"), &[], &title_rules),
+            Classification::Distraction
+        );
+    }
+
+    #[test]
+    fn test_title_rule_takes_priority_over_domain_rule() {
+        let domain_rules = vec![("youtube.com".to_string(), "Neutral".to_string())];
+        let title_rules = vec![(
+            "youtube.com".to_string(),
+            "강의".to_string(),
+            "Focus".to_string(),
+        )];
+        // title_rules가 domain_rules보다 우선
+        assert_eq!(
+            classify(Some("youtube.com"), Some("파이썬 강의 2024"), &domain_rules, &title_rules),
+            Classification::Focus
+        );
+    }
+
+    #[test]
+    fn test_no_title_skips_title_rules() {
+        let title_rules = vec![(
+            "youtube.com".to_string(),
+            "tutorial".to_string(),
+            "Focus".to_string(),
+        )];
+        // title이 None이면 title_rules 건너뛰고 내장 규칙 적용
+        assert_eq!(
+            classify(Some("youtube.com"), None, &[], &title_rules),
+            Classification::Distraction
+        );
     }
 }

--- a/src-tauri/src/services/classifier.rs
+++ b/src-tauri/src/services/classifier.rs
@@ -1,23 +1,22 @@
 use crate::models::activity::Classification;
 
 /// 활동 분류.
-/// 우선순위: title_rules (domain+keyword) > domain_rules (domain) > 내장 기본 규칙 > Neutral
+/// 우선순위: title_rules (domain+keyword) > domain_rules (domain) > app_rules (app_name) > 내장 기본 규칙 > Neutral
 ///
 /// - domain_rules: (domain, category) — DB classification_rules 테이블
 /// - title_rules: (domain, keyword, category) — DB title_rules 테이블
+/// - app_rules: (app_name, category) — DB app_rules 테이블
 /// - title: 현재 브라우저 탭 타이틀 (keyword 매칭에 사용)
 pub fn classify(
     domain: Option<&str>,
     title: Option<&str>,
+    app_name: Option<&str>,
     domain_rules: &[(String, String)],
     title_rules: &[(String, String, String)],
+    app_rules: &[(String, String)],
 ) -> Classification {
-    let Some(d) = domain else {
-        return Classification::Neutral;
-    };
-
     // 1순위: title_rules (domain + keyword 매칭, 대소문자 무시)
-    if let Some(t) = title {
+    if let (Some(d), Some(t)) = (domain, title) {
         let t_lower = t.to_lowercase();
         for (rule_domain, keyword, category) in title_rules {
             if rule_domain == d && t_lower.contains(&keyword.to_lowercase()) {
@@ -27,22 +26,37 @@ pub fn classify(
     }
 
     // 2순위: 사용자 정의 domain_rules
-    for (rule_domain, category) in domain_rules {
-        if rule_domain == d {
-            return parse_category(category);
+    if let Some(d) = domain {
+        for (rule_domain, category) in domain_rules {
+            if rule_domain == d {
+                return parse_category(category);
+            }
         }
     }
 
-    // 3순위: 내장 기본 규칙
-    match d {
-        "github.com" | "stackoverflow.com" | "docs.rs" | "developer.apple.com"
-        | "figma.com" | "notion.so" | "linear.app" => Classification::Focus,
+    // 3순위: 내장 기본 domain 규칙 (domain이 있을 때만)
+    if let Some(d) = domain {
+        return match d {
+            "github.com" | "stackoverflow.com" | "docs.rs" | "developer.apple.com"
+            | "figma.com" | "notion.so" | "linear.app" => Classification::Focus,
 
-        "youtube.com" | "twitter.com" | "x.com" | "instagram.com" | "reddit.com"
-        | "facebook.com" | "tiktok.com" | "netflix.com" => Classification::Distraction,
+            "youtube.com" | "twitter.com" | "x.com" | "instagram.com" | "reddit.com"
+            | "facebook.com" | "tiktok.com" | "netflix.com" => Classification::Distraction,
 
-        _ => Classification::Neutral,
+            _ => Classification::Neutral,
+        };
     }
+
+    // 4순위: app_rules — domain이 없는 네이티브 앱에만 적용
+    if let Some(a) = app_name {
+        for (rule_app, category) in app_rules {
+            if rule_app == a {
+                return parse_category(category);
+            }
+        }
+    }
+
+    Classification::Neutral
 }
 
 fn parse_category(s: &str) -> Classification {
@@ -61,38 +75,38 @@ mod tests {
     // 기존 테스트 — 새 시그니처에 맞게 빈 슬라이스 전달
     #[test]
     fn test_github_classified_as_focus() {
-        assert_eq!(classify(Some("github.com"), None, &[], &[]), Classification::Focus);
+        assert_eq!(classify(Some("github.com"), None, None, &[], &[], &[]), Classification::Focus);
     }
 
     #[test]
     fn test_stackoverflow_classified_as_focus() {
-        assert_eq!(classify(Some("stackoverflow.com"), None, &[], &[]), Classification::Focus);
+        assert_eq!(classify(Some("stackoverflow.com"), None, None, &[], &[], &[]), Classification::Focus);
     }
 
     #[test]
     fn test_youtube_classified_as_distraction() {
-        assert_eq!(classify(Some("youtube.com"), None, &[], &[]), Classification::Distraction);
+        assert_eq!(classify(Some("youtube.com"), None, None, &[], &[], &[]), Classification::Distraction);
     }
 
     #[test]
     fn test_twitter_classified_as_distraction() {
-        assert_eq!(classify(Some("twitter.com"), None, &[], &[]), Classification::Distraction);
+        assert_eq!(classify(Some("twitter.com"), None, None, &[], &[], &[]), Classification::Distraction);
     }
 
     #[test]
     fn test_unknown_domain_classified_as_neutral() {
-        assert_eq!(classify(Some("example.com"), None, &[], &[]), Classification::Neutral);
+        assert_eq!(classify(Some("example.com"), None, None, &[], &[], &[]), Classification::Neutral);
     }
 
     #[test]
     fn test_none_domain_classified_as_neutral() {
-        assert_eq!(classify(None, None, &[], &[]), Classification::Neutral);
+        assert_eq!(classify(None, None, None, &[], &[], &[]), Classification::Neutral);
     }
 
     #[test]
     fn test_custom_domain_rule_overrides_default() {
         let rules = vec![("example.com".to_string(), "Focus".to_string())];
-        assert_eq!(classify(Some("example.com"), None, &rules, &[]), Classification::Focus);
+        assert_eq!(classify(Some("example.com"), None, None, &rules, &[], &[]), Classification::Focus);
     }
 
     // title_rules 테스트
@@ -105,7 +119,7 @@ mod tests {
             "Focus".to_string(),
         )];
         assert_eq!(
-            classify(Some("youtube.com"), Some("Rust Tutorial 2024"), &[], &title_rules),
+            classify(Some("youtube.com"), Some("Rust Tutorial 2024"), None, &[], &title_rules, &[]),
             Classification::Focus
         );
     }
@@ -118,7 +132,7 @@ mod tests {
             "Focus".to_string(),
         )];
         assert_eq!(
-            classify(Some("youtube.com"), Some("TUTORIAL React"), &[], &title_rules),
+            classify(Some("youtube.com"), Some("TUTORIAL React"), None, &[], &title_rules, &[]),
             Classification::Focus
         );
     }
@@ -132,7 +146,7 @@ mod tests {
         )];
         // 타이틀에 keyword 없으면 기본 Distraction
         assert_eq!(
-            classify(Some("youtube.com"), Some("Music MV"), &[], &title_rules),
+            classify(Some("youtube.com"), Some("Music MV"), None, &[], &title_rules, &[]),
             Classification::Distraction
         );
     }
@@ -146,7 +160,7 @@ mod tests {
         )];
         // domain이 다르면 title_rule 무시, youtube.com 기본 규칙 적용
         assert_eq!(
-            classify(Some("youtube.com"), Some("tutorial"), &[], &title_rules),
+            classify(Some("youtube.com"), Some("tutorial"), None, &[], &title_rules, &[]),
             Classification::Distraction
         );
     }
@@ -161,7 +175,7 @@ mod tests {
         )];
         // title_rules가 domain_rules보다 우선
         assert_eq!(
-            classify(Some("youtube.com"), Some("파이썬 강의 2024"), &domain_rules, &title_rules),
+            classify(Some("youtube.com"), Some("파이썬 강의 2024"), None, &domain_rules, &title_rules, &[]),
             Classification::Focus
         );
     }
@@ -175,8 +189,45 @@ mod tests {
         )];
         // title이 None이면 title_rules 건너뛰고 내장 규칙 적용
         assert_eq!(
-            classify(Some("youtube.com"), None, &[], &title_rules),
+            classify(Some("youtube.com"), None, None, &[], &title_rules, &[]),
             Classification::Distraction
+        );
+    }
+
+    #[test]
+    fn test_app_rule_matches_native_app() {
+        let app_rules = vec![("Xcode".to_string(), "Focus".to_string())];
+        assert_eq!(
+            classify(None, None, Some("Xcode"), &[], &[], &app_rules),
+            Classification::Focus
+        );
+    }
+
+    #[test]
+    fn test_app_rule_distraction() {
+        let app_rules = vec![("Slack".to_string(), "Distraction".to_string())];
+        assert_eq!(
+            classify(None, None, Some("Slack"), &[], &[], &app_rules),
+            Classification::Distraction
+        );
+    }
+
+    #[test]
+    fn test_app_rule_priority_over_builtin_domain() {
+        // Chrome이라는 앱 이름에 Focus 규칙이 있어도, domain이 있으면 domain이 우선
+        let app_rules = vec![("Google Chrome".to_string(), "Focus".to_string())];
+        // youtube.com은 내장 Distraction, domain 규칙이 app_rule보다 우선
+        assert_eq!(
+            classify(Some("youtube.com"), None, Some("Google Chrome"), &[], &[], &app_rules),
+            Classification::Distraction
+        );
+    }
+
+    #[test]
+    fn test_no_app_rule_native_app_returns_neutral() {
+        assert_eq!(
+            classify(None, None, Some("UnknownApp"), &[], &[], &[]),
+            Classification::Neutral
         );
     }
 }

--- a/src-tauri/src/services/goal.rs
+++ b/src-tauri/src/services/goal.rs
@@ -1,0 +1,141 @@
+use rusqlite::{params, Connection};
+
+use crate::errors::AppError;
+use crate::models::goal::{DailyGoal, GoalProgress};
+
+/// 오늘 날짜 문자열 (YYYY-MM-DD)
+pub fn today() -> String {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    // 단순 계산 (UTC 기준)
+    let days = now / 86400;
+    let y = days_to_ymd(days);
+    y
+}
+
+fn days_to_ymd(days_since_epoch: u64) -> String {
+    // 1970-01-01 기준 경과 일수를 YYYY-MM-DD로 변환
+    // chrono 없이 간단히 계산
+    let mut d = days_since_epoch as i64;
+    let mut year = 1970i64;
+    loop {
+        let days_in_year = if is_leap(year) { 366 } else { 365 };
+        if d < days_in_year { break; }
+        d -= days_in_year;
+        year += 1;
+    }
+    let month_days: [i64; 12] = [31, if is_leap(year) { 29 } else { 28 }, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+    let mut month = 1i64;
+    for md in &month_days {
+        if d < *md { break; }
+        d -= md;
+        month += 1;
+    }
+    format!("{:04}-{:02}-{:02}", year, month, d + 1)
+}
+
+fn is_leap(y: i64) -> bool {
+    (y % 4 == 0 && y % 100 != 0) || y % 400 == 0
+}
+
+/// 특정 날짜의 목표 조회 (없으면 default_goal_secs 기본값 반환)
+pub fn get_daily_goal(conn: &Connection, date: &str) -> Result<DailyGoal, AppError> {
+    let result = conn.query_row(
+        "SELECT date, target_secs FROM session_goals WHERE date = ?1",
+        params![date],
+        |r| Ok(DailyGoal { date: r.get(0)?, target_secs: r.get(1)? }),
+    );
+    match result {
+        Ok(g) => Ok(g),
+        Err(_) => {
+            // 설정에서 기본 목표값 로드
+            let default_secs: i64 = conn
+                .query_row(
+                    "SELECT value FROM settings WHERE key = 'default_goal_secs'",
+                    [],
+                    |r| r.get::<_, String>(0),
+                )
+                .map(|v| v.parse().unwrap_or(7200))
+                .unwrap_or(7200);
+            Ok(DailyGoal { date: date.to_string(), target_secs: default_secs })
+        }
+    }
+}
+
+/// 특정 날짜의 목표 설정 (upsert)
+pub fn set_daily_goal(conn: &Connection, date: &str, target_secs: i64) -> Result<DailyGoal, AppError> {
+    conn.execute(
+        "INSERT OR REPLACE INTO session_goals (date, target_secs) VALUES (?1, ?2)",
+        params![date, target_secs],
+    )
+    .map_err(AppError::from)?;
+    Ok(DailyGoal { date: date.to_string(), target_secs })
+}
+
+/// 특정 날짜의 목표 달성 현황 조회
+pub fn get_goal_progress(conn: &Connection, date: &str) -> Result<GoalProgress, AppError> {
+    let goal = get_daily_goal(conn, date)?;
+
+    // 해당 날짜에 시작한 세션들의 Focus 시간 합산
+    let actual_focus_secs: i64 = conn
+        .query_row(
+            "SELECT COALESCE(SUM(a.duration_secs), 0)
+             FROM activities a
+             JOIN sessions s ON a.session_id = s.id
+             WHERE a.classification = 'Focus'
+               AND date(s.started_at, 'unixepoch') = ?1",
+            params![date],
+            |r| r.get(0),
+        )
+        .unwrap_or(0);
+
+    let progress_pct = if goal.target_secs > 0 {
+        (actual_focus_secs as f64 / goal.target_secs as f64 * 100.0).min(100.0)
+    } else {
+        0.0
+    };
+
+    Ok(GoalProgress {
+        date: date.to_string(),
+        target_secs: goal.target_secs,
+        actual_focus_secs,
+        progress_pct,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_today_format() {
+        let d = today();
+        // YYYY-MM-DD 형식 검증
+        assert_eq!(d.len(), 10);
+        assert_eq!(&d[4..5], "-");
+        assert_eq!(&d[7..8], "-");
+    }
+
+    #[test]
+    fn test_days_to_ymd_epoch() {
+        assert_eq!(days_to_ymd(0), "1970-01-01");
+    }
+
+    #[test]
+    fn test_days_to_ymd_known_date() {
+        // 2026-03-25 = 1970-01-01 + ?일
+        // 검증: 실제 today()와 비교하는 대신 형식만 확인
+        let d = days_to_ymd(20173); // 임의 날짜
+        assert_eq!(d.len(), 10);
+    }
+
+    #[test]
+    fn test_is_leap() {
+        assert!(is_leap(2000));
+        assert!(is_leap(2024));
+        assert!(!is_leap(1900));
+        assert!(!is_leap(2025));
+    }
+}

--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -4,6 +4,7 @@ pub mod browser;
 pub mod classifier;
 pub mod db;
 pub mod metrics;
+pub mod onboarding;
 pub mod reference;
 pub mod session;
 pub mod settings;

--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -1,9 +1,11 @@
 pub mod activity;
 pub mod archive;
 pub mod browser;
+pub mod goal;
 pub mod classifier;
 pub mod db;
 pub mod metrics;
+pub mod notification;
 pub mod onboarding;
 pub mod reference;
 pub mod session;

--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -6,4 +6,5 @@ pub mod db;
 pub mod metrics;
 pub mod reference;
 pub mod session;
+pub mod settings;
 pub mod tracker;

--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -1,3 +1,5 @@
+pub mod activity;
+pub mod archive;
 pub mod browser;
 pub mod classifier;
 pub mod db;

--- a/src-tauri/src/services/notification.rs
+++ b/src-tauri/src/services/notification.rs
@@ -1,0 +1,16 @@
+use tauri::AppHandle;
+use tauri_plugin_notification::NotificationExt;
+
+/// macOS 알림 전송
+pub fn send_notification(app: &AppHandle, title: &str, body: &str) {
+    let result = app
+        .notification()
+        .builder()
+        .title(title)
+        .body(body)
+        .show();
+
+    if let Err(e) = result {
+        eprintln!("[notification] 전송 실패: {e}");
+    }
+}

--- a/src-tauri/src/services/onboarding.rs
+++ b/src-tauri/src/services/onboarding.rs
@@ -1,0 +1,116 @@
+use rusqlite::{params, Connection};
+
+use crate::errors::AppError;
+use crate::models::onboarding::{Profession, TitleRule, profession_domain_rules};
+use crate::services::db::DbPool;
+
+/// 온보딩 완료 여부 조회
+pub fn is_onboarding_completed(conn: &Connection) -> bool {
+    conn.query_row(
+        "SELECT value FROM settings WHERE key = 'onboarding_completed'",
+        [],
+        |r| r.get::<_, String>(0),
+    )
+    .map(|v| v == "true")
+    .unwrap_or(false)
+}
+
+/// 온보딩 완료 처리
+pub fn complete_onboarding(conn: &Connection) -> Result<(), AppError> {
+    conn.execute(
+        "INSERT OR REPLACE INTO settings (key, value) VALUES ('onboarding_completed', 'true')",
+        [],
+    )
+    .map_err(AppError::from)?;
+    Ok(())
+}
+
+/// 직업 기반 사전 설정 규칙 적용 (기존 규칙 유지 + 신규 추가)
+pub fn apply_profession_rules(pool: &DbPool, profession: &Profession) -> Result<(), AppError> {
+    let conn = pool.get().map_err(AppError::from)?;
+    let rules = profession_domain_rules(profession);
+    for (domain, category) in rules {
+        conn.execute(
+            "INSERT OR IGNORE INTO classification_rules (domain, category) VALUES (?1, ?2)",
+            params![domain, category],
+        )
+        .map_err(AppError::from)?;
+    }
+    Ok(())
+}
+
+/// title_rule 추가
+pub fn add_title_rule(
+    conn: &Connection,
+    domain: &str,
+    keyword: &str,
+    category: &str,
+) -> Result<TitleRule, AppError> {
+    conn.execute(
+        "INSERT INTO title_rules (domain, keyword, category) VALUES (?1, ?2, ?3)",
+        params![domain, keyword, category],
+    )
+    .map_err(AppError::from)?;
+
+    let id = conn.last_insert_rowid();
+    Ok(TitleRule {
+        id,
+        domain: domain.to_string(),
+        keyword: keyword.to_string(),
+        category: category.to_string(),
+    })
+}
+
+/// title_rule 목록 조회
+pub fn get_title_rules(conn: &Connection) -> Result<Vec<TitleRule>, AppError> {
+    let mut stmt = conn
+        .prepare("SELECT id, domain, keyword, category FROM title_rules ORDER BY id")
+        .map_err(AppError::from)?;
+
+    let rows = stmt
+        .query_map([], |r| {
+            Ok(TitleRule {
+                id: r.get(0)?,
+                domain: r.get(1)?,
+                keyword: r.get(2)?,
+                category: r.get(3)?,
+            })
+        })
+        .map_err(AppError::from)?
+        .filter_map(|r| r.ok())
+        .collect();
+
+    Ok(rows)
+}
+
+/// title_rule 삭제
+pub fn delete_title_rule(conn: &Connection, id: i64) -> Result<(), AppError> {
+    let affected = conn
+        .execute("DELETE FROM title_rules WHERE id = ?1", params![id])
+        .map_err(AppError::from)?;
+
+    if affected == 0 {
+        return Err(AppError::NotFound(format!("title_rule id={id} 없음")));
+    }
+    Ok(())
+}
+
+/// 현재 활동의 분류를 즉시 변경 (이번 세션만)
+/// activity_id에 해당하는 activity의 classification 업데이트
+pub fn override_activity_classification(
+    conn: &Connection,
+    activity_id: &str,
+    category: &str,
+) -> Result<(), AppError> {
+    let affected = conn
+        .execute(
+            "UPDATE activities SET classification = ?1 WHERE id = ?2",
+            params![category, activity_id],
+        )
+        .map_err(AppError::from)?;
+
+    if affected == 0 {
+        return Err(AppError::NotFound(format!("activity id={activity_id} 없음")));
+    }
+    Ok(())
+}

--- a/src-tauri/src/services/reference.rs
+++ b/src-tauri/src/services/reference.rs
@@ -131,6 +131,55 @@ pub fn get_references(
     Ok(refs)
 }
 
+pub fn delete_reference(pool: &DbPool, id: &str) -> Result<(), AppError> {
+    let conn = pool.get().map_err(AppError::from)?;
+    let affected = conn
+        .execute(r#"DELETE FROM "references" WHERE id = ?1"#, rusqlite::params![id])
+        .map_err(AppError::from)?;
+    if affected == 0 {
+        return Err(AppError::NotFound(format!("reference {id} not found")));
+    }
+    Ok(())
+}
+
+pub fn update_reference(
+    pool: &DbPool,
+    id: &str,
+    title: &str,
+    tags: Vec<String>,
+) -> Result<Reference, AppError> {
+    let tags_json =
+        serde_json::to_string(&tags).map_err(|e| AppError::Internal(e.to_string()))?;
+
+    let conn = pool.get().map_err(AppError::from)?;
+    let affected = conn
+        .execute(
+            r#"UPDATE "references" SET title = ?1, tags = ?2 WHERE id = ?3"#,
+            rusqlite::params![title, tags_json, id],
+        )
+        .map_err(AppError::from)?;
+    if affected == 0 {
+        return Err(AppError::NotFound(format!("reference {id} not found")));
+    }
+
+    let (session_id, url, created_at): (String, String, i64) = conn
+        .query_row(
+            r#"SELECT session_id, url, created_at FROM "references" WHERE id = ?1"#,
+            rusqlite::params![id],
+            |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+        )
+        .map_err(AppError::from)?;
+
+    Ok(Reference {
+        id: id.to_string(),
+        session_id,
+        url,
+        title: title.to_string(),
+        tags,
+        created_at: unix_to_iso(created_at),
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src-tauri/src/services/settings.rs
+++ b/src-tauri/src/services/settings.rs
@@ -1,0 +1,94 @@
+use rusqlite::{params, Connection};
+
+use crate::errors::AppError;
+use crate::models::settings::{AppSettings, ClassificationRule};
+
+pub fn get_settings(conn: &Connection) -> Result<AppSettings, AppError> {
+    let retention_days: i64 = conn
+        .query_row(
+            "SELECT value FROM settings WHERE key = 'retention_days'",
+            [],
+            |r| r.get::<_, String>(0),
+        )
+        .map(|v| v.parse().unwrap_or(30))
+        .unwrap_or(30);
+
+    let shortcut_save_ref: String = conn
+        .query_row(
+            "SELECT value FROM settings WHERE key = 'shortcut_save_ref'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap_or_else(|_| "CmdOrCtrl+Shift+R".to_string());
+
+    Ok(AppSettings {
+        retention_days,
+        shortcut_save_ref,
+    })
+}
+
+pub fn update_settings(conn: &Connection, settings: &AppSettings) -> Result<(), AppError> {
+    conn.execute(
+        "INSERT OR REPLACE INTO settings (key, value) VALUES ('retention_days', ?1)",
+        params![settings.retention_days.to_string()],
+    )
+    .map_err(AppError::from)?;
+
+    conn.execute(
+        "INSERT OR REPLACE INTO settings (key, value) VALUES ('shortcut_save_ref', ?1)",
+        params![settings.shortcut_save_ref],
+    )
+    .map_err(AppError::from)?;
+
+    Ok(())
+}
+
+pub fn get_classification_rules(conn: &Connection) -> Result<Vec<ClassificationRule>, AppError> {
+    let mut stmt = conn
+        .prepare("SELECT id, domain, category FROM classification_rules ORDER BY id")
+        .map_err(AppError::from)?;
+
+    let rules = stmt
+        .query_map([], |r| {
+            Ok(ClassificationRule {
+                id: r.get(0)?,
+                domain: r.get(1)?,
+                category: r.get(2)?,
+            })
+        })
+        .map_err(AppError::from)?
+        .filter_map(|r| r.ok())
+        .collect();
+
+    Ok(rules)
+}
+
+pub fn add_classification_rule(
+    conn: &Connection,
+    domain: &str,
+    category: &str,
+) -> Result<ClassificationRule, AppError> {
+    conn.execute(
+        "INSERT INTO classification_rules (domain, category) VALUES (?1, ?2)",
+        params![domain, category],
+    )
+    .map_err(AppError::from)?;
+
+    let id = conn.last_insert_rowid();
+    Ok(ClassificationRule {
+        id,
+        domain: domain.to_string(),
+        category: category.to_string(),
+    })
+}
+
+pub fn delete_classification_rule(conn: &Connection, id: i64) -> Result<(), AppError> {
+    let affected = conn
+        .execute("DELETE FROM classification_rules WHERE id = ?1", params![id])
+        .map_err(AppError::from)?;
+
+    if affected == 0 {
+        return Err(AppError::NotFound(format!("규칙 id={id} 없음")));
+    }
+    Ok(())
+}

--- a/src-tauri/src/services/settings.rs
+++ b/src-tauri/src/services/settings.rs
@@ -180,3 +180,4 @@ pub fn delete_app_rule(conn: &Connection, id: i64) -> Result<(), AppError> {
     }
     Ok(())
 }
+

--- a/src-tauri/src/services/settings.rs
+++ b/src-tauri/src/services/settings.rs
@@ -21,9 +21,27 @@ pub fn get_settings(conn: &Connection) -> Result<AppSettings, AppError> {
         )
         .unwrap_or_else(|_| "CmdOrCtrl+Shift+R".to_string());
 
+    let shortcut_session_start: String = conn
+        .query_row(
+            "SELECT value FROM settings WHERE key = 'shortcut_session_start'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap_or_else(|_| "CmdOrCtrl+Shift+S".to_string());
+
+    let shortcut_session_end: String = conn
+        .query_row(
+            "SELECT value FROM settings WHERE key = 'shortcut_session_end'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap_or_else(|_| "CmdOrCtrl+Shift+E".to_string());
+
     Ok(AppSettings {
         retention_days,
         shortcut_save_ref,
+        shortcut_session_start,
+        shortcut_session_end,
     })
 }
 
@@ -37,6 +55,18 @@ pub fn update_settings(conn: &Connection, settings: &AppSettings) -> Result<(), 
     conn.execute(
         "INSERT OR REPLACE INTO settings (key, value) VALUES ('shortcut_save_ref', ?1)",
         params![settings.shortcut_save_ref],
+    )
+    .map_err(AppError::from)?;
+
+    conn.execute(
+        "INSERT OR REPLACE INTO settings (key, value) VALUES ('shortcut_session_start', ?1)",
+        params![settings.shortcut_session_start],
+    )
+    .map_err(AppError::from)?;
+
+    conn.execute(
+        "INSERT OR REPLACE INTO settings (key, value) VALUES ('shortcut_session_end', ?1)",
+        params![settings.shortcut_session_end],
     )
     .map_err(AppError::from)?;
 

--- a/src-tauri/src/services/settings.rs
+++ b/src-tauri/src/services/settings.rs
@@ -3,6 +3,13 @@ use rusqlite::{params, Connection};
 use crate::errors::AppError;
 use crate::models::settings::{AppSettings, ClassificationRule};
 
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub struct AppRule {
+    pub id: i64,
+    pub app_name: String,
+    pub category: String,
+}
+
 pub fn get_settings(conn: &Connection) -> Result<AppSettings, AppError> {
     let retention_days: i64 = conn
         .query_row(
@@ -119,6 +126,57 @@ pub fn delete_classification_rule(conn: &Connection, id: i64) -> Result<(), AppE
 
     if affected == 0 {
         return Err(AppError::NotFound(format!("규칙 id={id} 없음")));
+    }
+    Ok(())
+}
+
+pub fn get_app_rules(conn: &Connection) -> Result<Vec<AppRule>, AppError> {
+    let mut stmt = conn
+        .prepare("SELECT id, app_name, category FROM app_rules ORDER BY app_name ASC")
+        .map_err(AppError::from)?;
+
+    let rules = stmt
+        .query_map([], |r| {
+            Ok(AppRule {
+                id: r.get(0)?,
+                app_name: r.get(1)?,
+                category: r.get(2)?,
+            })
+        })
+        .map_err(AppError::from)?
+        .filter_map(|r| r.ok())
+        .collect();
+
+    Ok(rules)
+}
+
+pub fn add_app_rule(
+    conn: &Connection,
+    app_name: &str,
+    category: &str,
+) -> Result<AppRule, AppError> {
+    conn.execute(
+        "INSERT INTO app_rules (app_name, category) VALUES (?1, ?2)
+         ON CONFLICT(app_name) DO UPDATE SET category = excluded.category",
+        params![app_name, category],
+    )
+    .map_err(AppError::from)?;
+
+    let id = conn.last_insert_rowid();
+    Ok(AppRule {
+        id,
+        app_name: app_name.to_string(),
+        category: category.to_string(),
+    })
+}
+
+pub fn delete_app_rule(conn: &Connection, id: i64) -> Result<(), AppError> {
+    let affected = conn
+        .execute("DELETE FROM app_rules WHERE id = ?1", params![id])
+        .map_err(AppError::from)?;
+
+    if affected == 0 {
+        return Err(AppError::NotFound(format!("앱 규칙 id={id} 없음")));
     }
     Ok(())
 }

--- a/src-tauri/src/services/tracker.rs
+++ b/src-tauri/src/services/tracker.rs
@@ -14,6 +14,7 @@ struct CurrentActivity {
     app_name: String,
     url: Option<String>,
     domain: Option<String>,
+    title: Option<String>,
     started_at: i64,
 }
 
@@ -80,10 +81,16 @@ pub fn start_tracker(
                 match &prev {
                     Some(p) if p.is_same(&app_name, url.as_deref()) => {}
                     _ => {
+                        let title = if url.is_some() {
+                            browser::get_browser_title(&app_name)
+                        } else {
+                            None
+                        };
                         prev = Some(CurrentActivity {
                             app_name,
                             url,
                             domain,
+                            title,
                             started_at: now,
                         });
                     }
@@ -124,8 +131,8 @@ fn poll_once(
                 let classification = classifier::classify(prev.domain.as_deref(), &rules);
 
                 conn.execute(
-                    "INSERT INTO activities (id, session_id, app_name, url, domain, classification, started_at, duration_secs)
-                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+                    "INSERT INTO activities (id, session_id, app_name, url, domain, classification, started_at, duration_secs, title)
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
                     rusqlite::params![
                         uuid::Uuid::new_v4().to_string(),
                         session_id,
@@ -135,6 +142,7 @@ fn poll_once(
                         classification_to_str(&classification),
                         prev.started_at,
                         duration,
+                        prev.title,
                     ],
                 )
                 .map_err(AppError::from)?;

--- a/src-tauri/src/services/tracker.rs
+++ b/src-tauri/src/services/tracker.rs
@@ -127,8 +127,14 @@ fn poll_once(
             if duration > 0 {
                 // 이전 활동 저장
                 let conn = db_pool.get().map_err(AppError::from)?;
-                let rules = load_rules(&conn)?;
-                let classification = classifier::classify(prev.domain.as_deref(), &rules);
+                let domain_rules = load_domain_rules(&conn)?;
+                let title_rules = load_title_rules(&conn)?;
+                let classification = classifier::classify(
+                    prev.domain.as_deref(),
+                    prev.title.as_deref(),
+                    &domain_rules,
+                    &title_rules,
+                );
 
                 conn.execute(
                     "INSERT INTO activities (id, session_id, app_name, url, domain, classification, started_at, duration_secs, title)
@@ -153,18 +159,30 @@ fn poll_once(
     Ok(())
 }
 
-fn load_rules(conn: &rusqlite::Connection) -> Result<Vec<(String, String)>, AppError> {
+fn load_domain_rules(conn: &rusqlite::Connection) -> Result<Vec<(String, String)>, AppError> {
     let mut stmt = conn
         .prepare("SELECT domain, category FROM classification_rules")
         .map_err(AppError::from)?;
 
-    let rules = stmt
+    let rows = stmt
         .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
         .map_err(AppError::from)?
         .collect::<Result<Vec<_>, _>>()
         .map_err(AppError::from)?;
+    Ok(rows)
+}
 
-    Ok(rules)
+fn load_title_rules(conn: &rusqlite::Connection) -> Result<Vec<(String, String, String)>, AppError> {
+    let mut stmt = conn
+        .prepare("SELECT domain, keyword, category FROM title_rules")
+        .map_err(AppError::from)?;
+
+    let rows = stmt
+        .query_map([], |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)))
+        .map_err(AppError::from)?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(AppError::from)?;
+    Ok(rows)
 }
 
 fn classification_to_str(c: &Classification) -> &'static str {

--- a/src-tauri/src/services/tracker.rs
+++ b/src-tauri/src/services/tracker.rs
@@ -7,7 +7,7 @@ use crate::models::activity::Classification;
 use crate::services::{browser, classifier};
 use crate::services::db::DbPool;
 
-const POLL_INTERVAL_SECS: u64 = 2;
+const POLL_INTERVAL_SECS: u64 = 1;
 
 #[derive(Clone, Debug)]
 struct CurrentActivity {
@@ -63,18 +63,23 @@ pub fn start_tracker(
         let mut goal_notified = false;
 
         loop {
-            async_runtime::spawn_blocking({
+            // 현재 상태 감지 + 이전 활동 저장 + prev 업데이트를 한 번의 blocking 작업으로 처리
+            // — osascript(get_browser_url) 를 루프당 1회만 호출
+            let new_prev = async_runtime::spawn_blocking({
                 let db_pool = db_pool.clone();
                 let session_id = session_id.clone();
                 let prev_clone = prev.clone();
-                move || {
-                    poll_once(&db_pool, &session_id, prev_clone)
-                }
+                move || poll_and_update(&db_pool, &session_id, prev_clone)
             })
             .await
-            .ok();
+            .ok()
+            .flatten();
 
-            // 알림 체크 (30초마다)
+            if let Some(p) = new_prev {
+                prev = Some(p);
+            }
+
+            // 알림 체크
             let now = now_unix();
             let should_check = last_low_focus_notify.map(|t| now - t > 600).unwrap_or(true);
             if should_check {
@@ -88,92 +93,80 @@ pub fn start_tracker(
                 );
             }
 
-            // prev 업데이트를 위해 현재 상태 다시 가져오기
-            let app_name = get_frontmost_app();
-            if let Some(app_name) = app_name {
-                let url = browser::get_browser_url(&app_name);
-                let domain = url.as_deref().and_then(browser::extract_domain).map(|d| d);
-                let now = now_unix();
-
-                match &prev {
-                    Some(p) if p.is_same(&app_name, url.as_deref()) => {}
-                    _ => {
-                        let title = if url.is_some() {
-                            browser::get_browser_title(&app_name)
-                        } else {
-                            None
-                        };
-                        prev = Some(CurrentActivity {
-                            app_name,
-                            url,
-                            domain,
-                            title,
-                            started_at: now,
-                        });
-                    }
-                }
-            }
-
-            tauri::async_runtime::spawn(async move {
-                tokio::time::sleep(Duration::from_secs(POLL_INTERVAL_SECS)).await;
-            })
-            .await
-            .ok();
+            tokio::time::sleep(Duration::from_secs(POLL_INTERVAL_SECS)).await;
         }
     })
 }
 
-fn poll_once(
+/// 현재 앱/URL을 한 번 감지하고, prev와 달라졌으면 이전 활동을 DB에 저장한 뒤
+/// 새로운 CurrentActivity를 반환한다. osascript 호출이 루프당 1회로 줄어든다.
+fn poll_and_update(
     db_pool: &DbPool,
     session_id: &str,
     prev: Option<CurrentActivity>,
-) -> Result<(), AppError> {
-    let app_name = match get_frontmost_app() {
-        Some(n) => n,
-        None => return Ok(()),
-    };
-
-    let url = browser::get_browser_url(&app_name);
-    let _domain = url.as_deref().and_then(|u| browser::extract_domain(u));
+) -> Option<CurrentActivity> {
+    let app_name = get_frontmost_app()?;
+    let url = browser::get_browser_url(&app_name); // osascript — 루프당 1회
     let now = now_unix();
 
-    // 활동 변경 감지
-    if let Some(prev) = prev {
-        if !prev.is_same(&app_name, url.as_deref()) {
-            let duration = now - prev.started_at;
-            if duration > 0 {
-                // 이전 활동 저장
-                let conn = db_pool.get().map_err(AppError::from)?;
-                let domain_rules = load_domain_rules(&conn)?;
-                let title_rules = load_title_rules(&conn)?;
-                let classification = classifier::classify(
-                    prev.domain.as_deref(),
-                    prev.title.as_deref(),
-                    &domain_rules,
-                    &title_rules,
-                );
+    let changed = match &prev {
+        Some(p) => !p.is_same(&app_name, url.as_deref()),
+        None => true,
+    };
 
-                conn.execute(
-                    "INSERT INTO activities (id, session_id, app_name, url, domain, classification, started_at, duration_secs, title)
-                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
-                    rusqlite::params![
-                        uuid::Uuid::new_v4().to_string(),
-                        session_id,
-                        prev.app_name,
-                        prev.url,
-                        prev.domain,
-                        classification_to_str(&classification),
-                        prev.started_at,
-                        duration,
-                        prev.title,
-                    ],
-                )
-                .map_err(AppError::from)?;
+    if changed {
+        // 이전 활동 저장
+        if let Some(ref p) = prev {
+            let duration = now - p.started_at;
+            if duration > 0 {
+                if let Ok(conn) = db_pool.get() {
+                    if let (Ok(domain_rules), Ok(title_rules), Ok(app_rules)) = (
+                        load_domain_rules(&conn),
+                        load_title_rules(&conn),
+                        load_app_rules(&conn),
+                    ) {
+                        let classification = classifier::classify(
+                            p.domain.as_deref(),
+                            p.title.as_deref(),
+                            Some(&p.app_name),
+                            &domain_rules,
+                            &title_rules,
+                            &app_rules,
+                        );
+                        let _ = conn.execute(
+                            "INSERT INTO activities \
+                             (id, session_id, app_name, url, domain, classification, started_at, duration_secs, title) \
+                             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+                            rusqlite::params![
+                                uuid::Uuid::new_v4().to_string(),
+                                session_id,
+                                p.app_name,
+                                p.url,
+                                p.domain,
+                                classification_to_str(&classification),
+                                p.started_at,
+                                duration,
+                                p.title,
+                            ],
+                        );
+                    }
+                }
             }
         }
-    }
 
-    Ok(())
+        // 타이틀은 변경 시점에만 가져옴 (osascript 추가 호출)
+        let title = if url.is_some() {
+            browser::get_browser_title(&app_name)
+        } else {
+            None
+        };
+        let domain = url.as_deref().and_then(|u| browser::extract_domain(u));
+
+        Some(CurrentActivity { app_name, url, domain, title, started_at: now })
+    } else {
+        // 동일 활동 — prev 그대로 유지
+        prev
+    }
 }
 
 fn load_domain_rules(conn: &rusqlite::Connection) -> Result<Vec<(String, String)>, AppError> {
@@ -196,6 +189,19 @@ fn load_title_rules(conn: &rusqlite::Connection) -> Result<Vec<(String, String, 
 
     let rows = stmt
         .query_map([], |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)))
+        .map_err(AppError::from)?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(AppError::from)?;
+    Ok(rows)
+}
+
+fn load_app_rules(conn: &rusqlite::Connection) -> Result<Vec<(String, String)>, AppError> {
+    let mut stmt = conn
+        .prepare("SELECT app_name, category FROM app_rules")
+        .map_err(AppError::from)?;
+
+    let rows = stmt
+        .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
         .map_err(AppError::from)?
         .collect::<Result<Vec<_>, _>>()
         .map_err(AppError::from)?;

--- a/src-tauri/src/services/tracker.rs
+++ b/src-tauri/src/services/tracker.rs
@@ -52,12 +52,15 @@ fn get_frontmost_app() -> Option<String> {
 }
 
 pub fn start_tracker(
-    _app_handle: AppHandle,
+    app_handle: AppHandle,
     db_pool: DbPool,
     session_id: String,
 ) -> JoinHandle<()> {
     async_runtime::spawn(async move {
         let mut prev: Option<CurrentActivity> = None;
+        // 알림 쿨다운: 마지막 알림 전송 시각 (중복 방지)
+        let mut last_low_focus_notify: Option<i64> = None;
+        let mut goal_notified = false;
 
         loop {
             async_runtime::spawn_blocking({
@@ -70,6 +73,20 @@ pub fn start_tracker(
             })
             .await
             .ok();
+
+            // 알림 체크 (30초마다)
+            let now = now_unix();
+            let should_check = last_low_focus_notify.map(|t| now - t > 600).unwrap_or(true);
+            if should_check {
+                check_notifications(
+                    &app_handle,
+                    &db_pool,
+                    &session_id,
+                    now,
+                    &mut last_low_focus_notify,
+                    &mut goal_notified,
+                );
+            }
 
             // prev 업데이트를 위해 현재 상태 다시 가져오기
             let app_name = get_frontmost_app();
@@ -190,5 +207,87 @@ fn classification_to_str(c: &Classification) -> &'static str {
         Classification::Focus => "Focus",
         Classification::Neutral => "Neutral",
         Classification::Distraction => "Distraction",
+    }
+}
+
+/// 알림 조건 체크 및 전송
+fn check_notifications(
+    app: &AppHandle,
+    db_pool: &DbPool,
+    session_id: &str,
+    now: i64,
+    last_low_focus_notify: &mut Option<i64>,
+    goal_notified: &mut bool,
+) {
+    let Ok(conn) = db_pool.get() else { return; };
+
+    // 알림 활성화 여부 확인
+    let notify_enabled: bool = conn
+        .query_row(
+            "SELECT value FROM settings WHERE key = 'notify_enabled'",
+            [],
+            |r| r.get::<_, String>(0),
+        )
+        .map(|v| v == "true")
+        .unwrap_or(true);
+    if !notify_enabled { return; }
+
+    // 집중도 임계값 로드
+    let threshold: i64 = conn
+        .query_row(
+            "SELECT value FROM settings WHERE key = 'notify_low_focus_threshold'",
+            [],
+            |r| r.get::<_, String>(0),
+        )
+        .map(|v| v.parse().unwrap_or(40))
+        .unwrap_or(40);
+
+    // 세션 시작 시각
+    let Ok(started_at) = conn.query_row(
+        "SELECT started_at FROM sessions WHERE id = ?1",
+        rusqlite::params![session_id],
+        |r| r.get::<_, i64>(0),
+    ) else { return; };
+
+    let elapsed = now - started_at;
+    // 10분 미만 세션은 알림 없음
+    if elapsed < 600 { return; }
+
+    // 최근 10분간 집중 시간 계산
+    let since = now - 600;
+    let focus_secs: i64 = conn
+        .query_row(
+            "SELECT COALESCE(SUM(duration_secs), 0)
+             FROM activities
+             WHERE session_id = ?1 AND classification = 'Focus'
+               AND started_at >= ?2",
+            rusqlite::params![session_id, since],
+            |r| r.get(0),
+        )
+        .unwrap_or(0);
+
+    let focus_pct = (focus_secs * 100) / 600;
+    if focus_pct < threshold {
+        *last_low_focus_notify = Some(now);
+        crate::services::notification::send_notification(
+            app,
+            "집중도 경고",
+            &format!("최근 10분간 집중도가 {}%입니다. 방해 요소를 줄여보세요!", focus_pct),
+        );
+    }
+
+    // 목표 달성 알림 (1회만)
+    if !*goal_notified {
+        let today = crate::services::goal::today();
+        if let Ok(progress) = crate::services::goal::get_goal_progress(&conn, &today) {
+            if progress.progress_pct >= 100.0 {
+                *goal_notified = true;
+                crate::services::notification::send_notification(
+                    app,
+                    "목표 달성! 🎉",
+                    &format!("오늘 집중 목표 {}분을 달성했습니다!", progress.target_secs / 60),
+                );
+            }
+        }
     }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -16,7 +16,7 @@
         "label": "dropdown",
         "title": "focaro",
         "width": 320,
-        "height": 480,
+        "height": 540,
         "decorations": false,
         "transparent": true,
         "visible": false,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -49,6 +49,16 @@
         "visible": false,
         "resizable": false,
         "decorations": true
+      },
+      {
+        "label": "onboarding",
+        "title": "focaro 시작하기",
+        "width": 520,
+        "height": 460,
+        "visible": false,
+        "resizable": false,
+        "decorations": true,
+        "center": true
       }
     ],
     "security": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -26,38 +26,43 @@
       },
       {
         "label": "dashboard",
-        "title": "focaro Dashboard",
+        "title": "",
         "width": 900,
         "height": 650,
         "visible": false,
-        "resizable": true
+        "resizable": true,
+        "titleBarStyle": "Overlay",
+        "hiddenTitle": true
       },
       {
         "label": "save-reference",
-        "title": "Reference 저장",
+        "title": "",
         "width": 480,
         "height": 280,
         "visible": false,
         "resizable": false,
-        "decorations": true
+        "titleBarStyle": "Overlay",
+        "hiddenTitle": true
       },
       {
         "label": "settings",
-        "title": "focaro 설정",
+        "title": "",
         "width": 600,
         "height": 500,
         "visible": false,
         "resizable": false,
-        "decorations": true
+        "titleBarStyle": "Overlay",
+        "hiddenTitle": true
       },
       {
         "label": "onboarding",
-        "title": "focaro 시작하기",
+        "title": "",
         "width": 520,
         "height": 460,
         "visible": false,
         "resizable": false,
-        "decorations": true,
+        "titleBarStyle": "Overlay",
+        "hiddenTitle": true,
         "center": true
       }
     ],

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -31,6 +31,24 @@
         "height": 650,
         "visible": false,
         "resizable": true
+      },
+      {
+        "label": "save-reference",
+        "title": "Reference 저장",
+        "width": 480,
+        "height": 280,
+        "visible": false,
+        "resizable": false,
+        "decorations": true
+      },
+      {
+        "label": "settings",
+        "title": "focaro 설정",
+        "width": 600,
+        "height": 500,
+        "visible": false,
+        "resizable": false,
+        "decorations": true
       }
     ],
     "security": {

--- a/src-tauri/tests/activity_tests.rs
+++ b/src-tauri/tests/activity_tests.rs
@@ -94,8 +94,9 @@ mod tests {
 
         let rows = activity::query_activity_timeline(&pool, &date).unwrap();
         assert_eq!(rows.len(), 2, "날짜에 맞는 활동 2개");
-        assert_eq!(rows[0].app_name, "Chrome");
-        assert_eq!(rows[1].app_name, "Slack");
+        // DESC 정렬: 최신 활동이 먼저
+        assert_eq!(rows[0].app_name, "Slack");
+        assert_eq!(rows[1].app_name, "Chrome");
     }
 
     #[test]
@@ -109,8 +110,9 @@ mod tests {
         insert_activity_with_domain(&pool, "s1", "Chrome", Some("github.com"), "Focus", 60, ts);
 
         let rows = activity::query_activity_timeline(&pool, &date).unwrap();
-        assert_eq!(rows[0].app_name, "Chrome", "시간순 정렬: Chrome이 먼저");
-        assert_eq!(rows[1].app_name, "Slack");
+        // DESC 정렬: 최신(Slack, ts+120)이 먼저
+        assert_eq!(rows[0].app_name, "Slack", "DESC 정렬: Slack이 먼저");
+        assert_eq!(rows[1].app_name, "Chrome");
     }
 
     #[test]

--- a/src-tauri/tests/activity_tests.rs
+++ b/src-tauri/tests/activity_tests.rs
@@ -1,0 +1,266 @@
+// activity 서비스 통합 테스트 — in-memory SQLite 사용
+#[cfg(test)]
+mod tests {
+    use focaro_lib::services::db;
+    use focaro_lib::services::activity;
+    use r2d2_sqlite::SqliteConnectionManager;
+
+    fn setup_pool() -> r2d2::Pool<SqliteConnectionManager> {
+        let manager = SqliteConnectionManager::memory();
+        let pool = r2d2::Pool::new(manager).unwrap();
+        let mut conn = pool.get().unwrap();
+        db::run_migrations(&mut *conn).unwrap();
+        drop(conn);
+        pool
+    }
+
+    fn insert_session(pool: &r2d2::Pool<SqliteConnectionManager>, id: &str, started_at: i64) {
+        let conn = pool.get().unwrap();
+        conn.execute(
+            "INSERT INTO sessions (id, started_at, ended_at, is_complete) VALUES (?1, ?2, ?2, 1)",
+            rusqlite::params![id, started_at],
+        )
+        .unwrap();
+    }
+
+    fn insert_activity_with_domain(
+        pool: &r2d2::Pool<SqliteConnectionManager>,
+        session_id: &str,
+        app_name: &str,
+        domain: Option<&str>,
+        classification: &str,
+        duration_secs: i64,
+        started_at: i64,
+    ) {
+        let conn = pool.get().unwrap();
+        conn.execute(
+            "INSERT INTO activities (id, session_id, app_name, url, domain, classification, started_at, duration_secs)
+             VALUES (?, ?, ?, NULL, ?, ?, ?, ?)",
+            rusqlite::params![
+                uuid::Uuid::new_v4().to_string(),
+                session_id,
+                app_name,
+                domain,
+                classification,
+                started_at,
+                duration_secs,
+            ],
+        )
+        .unwrap();
+    }
+
+    fn now_unix() -> i64 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64
+    }
+
+    /// 오늘 UTC 날짜 문자열 ("YYYY-MM-DD")
+    fn today_date() -> String {
+        let now = now_unix();
+        chrono::DateTime::from_timestamp(now, 0)
+            .map(|dt| dt.format("%Y-%m-%d").to_string())
+            .unwrap_or_default()
+    }
+
+    /// 어제 UTC 날짜 문자열 + 어제 시작 unix timestamp
+    fn yesterday() -> (String, i64) {
+        let ts = now_unix() - 86400;
+        let date = chrono::DateTime::from_timestamp(ts, 0)
+            .map(|dt| dt.format("%Y-%m-%d").to_string())
+            .unwrap_or_default();
+        (date, ts)
+    }
+
+    /// 오늘 UTC 00:00 ~ 00:30 사이의 unix timestamp (항상 오늘 날짜에 속함)
+    fn today_ts() -> i64 {
+        let now = now_unix();
+        // 오늘 UTC 00:00 을 구하기
+        let days = now / 86400;
+        days * 86400 + 1800 // 00:30 UTC
+    }
+
+    // ── get_activity_timeline 테스트 ──────────────────────────────
+
+    #[test]
+    fn test_activity_timeline_returns_activities_for_date() {
+        let pool = setup_pool();
+        let ts = today_ts();
+        let date = today_date();
+        insert_session(&pool, "s1", ts);
+        insert_activity_with_domain(&pool, "s1", "Chrome", Some("github.com"), "Focus", 60, ts);
+        insert_activity_with_domain(&pool, "s1", "Slack", None, "Neutral", 30, ts + 60);
+
+        let rows = activity::query_activity_timeline(&pool, &date).unwrap();
+        assert_eq!(rows.len(), 2, "날짜에 맞는 활동 2개");
+        assert_eq!(rows[0].app_name, "Chrome");
+        assert_eq!(rows[1].app_name, "Slack");
+    }
+
+    #[test]
+    fn test_activity_timeline_sorted_by_time() {
+        let pool = setup_pool();
+        let ts = today_ts();
+        let date = today_date();
+        insert_session(&pool, "s1", ts);
+        // 나중 것을 먼저 삽입
+        insert_activity_with_domain(&pool, "s1", "Slack", None, "Neutral", 30, ts + 120);
+        insert_activity_with_domain(&pool, "s1", "Chrome", Some("github.com"), "Focus", 60, ts);
+
+        let rows = activity::query_activity_timeline(&pool, &date).unwrap();
+        assert_eq!(rows[0].app_name, "Chrome", "시간순 정렬: Chrome이 먼저");
+        assert_eq!(rows[1].app_name, "Slack");
+    }
+
+    #[test]
+    fn test_activity_timeline_empty_for_other_date() {
+        let pool = setup_pool();
+        let ts = today_ts();
+        let date = today_date();
+        insert_session(&pool, "s1", ts);
+        insert_activity_with_domain(&pool, "s1", "Chrome", None, "Focus", 60, ts);
+
+        // 어제 날짜 조회 → 빈 배열
+        let (yesterday_date, _) = yesterday();
+        if yesterday_date != date {
+            let rows = activity::query_activity_timeline(&pool, &yesterday_date).unwrap();
+            assert!(rows.is_empty(), "다른 날짜엔 활동 없음");
+        }
+    }
+
+    #[test]
+    fn test_activity_timeline_includes_classification() {
+        let pool = setup_pool();
+        let ts = today_ts();
+        let date = today_date();
+        insert_session(&pool, "s1", ts);
+        insert_activity_with_domain(&pool, "s1", "YouTube", Some("youtube.com"), "Distraction", 30, ts);
+
+        let rows = activity::query_activity_timeline(&pool, &date).unwrap();
+        assert_eq!(rows[0].classification, "Distraction");
+        assert_eq!(rows[0].domain.as_deref(), Some("youtube.com"));
+    }
+
+    // ── get_top_sites 테스트 ──────────────────────────────────────
+
+    #[test]
+    fn test_top_sites_sorted_by_duration_desc() {
+        let pool = setup_pool();
+        let ts = today_ts();
+        let date = today_date();
+        insert_session(&pool, "s1", ts);
+        insert_activity_with_domain(&pool, "s1", "Chrome", Some("github.com"), "Focus", 30, ts);
+        insert_activity_with_domain(&pool, "s1", "Chrome", Some("youtube.com"), "Distraction", 90, ts + 30);
+        insert_activity_with_domain(&pool, "s1", "Chrome", Some("slack.com"), "Neutral", 60, ts + 120);
+
+        let sites = activity::query_top_sites(&pool, &date, 10).unwrap();
+        assert_eq!(sites[0].domain, "youtube.com", "youtube가 최장 시간");
+        assert_eq!(sites[0].total_secs, 90);
+        assert_eq!(sites[1].domain, "slack.com");
+        assert_eq!(sites[2].domain, "github.com");
+    }
+
+    #[test]
+    fn test_top_sites_aggregates_same_domain() {
+        let pool = setup_pool();
+        let ts = today_ts();
+        let date = today_date();
+        insert_session(&pool, "s1", ts);
+        insert_activity_with_domain(&pool, "s1", "Chrome", Some("github.com"), "Focus", 40, ts);
+        insert_activity_with_domain(&pool, "s1", "Chrome", Some("github.com"), "Focus", 60, ts + 40);
+
+        let sites = activity::query_top_sites(&pool, &date, 10).unwrap();
+        assert_eq!(sites.len(), 1, "같은 도메인은 합산");
+        assert_eq!(sites[0].total_secs, 100, "40+60=100");
+    }
+
+    #[test]
+    fn test_top_sites_null_domain_excluded() {
+        let pool = setup_pool();
+        let ts = today_ts();
+        let date = today_date();
+        insert_session(&pool, "s1", ts);
+        insert_activity_with_domain(&pool, "s1", "Xcode", None, "Neutral", 120, ts);
+        insert_activity_with_domain(&pool, "s1", "Chrome", Some("github.com"), "Focus", 60, ts + 120);
+
+        let sites = activity::query_top_sites(&pool, &date, 10).unwrap();
+        assert_eq!(sites.len(), 1, "NULL 도메인 제외");
+        assert_eq!(sites[0].domain, "github.com");
+    }
+
+    #[test]
+    fn test_top_sites_limit_respected() {
+        let pool = setup_pool();
+        let ts = today_ts();
+        let date = today_date();
+        insert_session(&pool, "s1", ts);
+        for i in 0..8i64 {
+            let domain = format!("site{}.com", i);
+            insert_activity_with_domain(&pool, "s1", "Chrome", Some(domain.as_str()), "Neutral", 10, ts + i * 10);
+        }
+
+        let sites = activity::query_top_sites(&pool, &date, 5).unwrap();
+        assert_eq!(sites.len(), 5, "limit 5 적용");
+    }
+
+    #[test]
+    fn test_top_sites_empty_date_returns_empty() {
+        let pool = setup_pool();
+        let (yesterday_date, _) = yesterday();
+        let sites = activity::query_top_sites(&pool, &yesterday_date, 10).unwrap();
+        assert!(sites.is_empty());
+    }
+
+    // ── get_daily_focus_stats 테스트 ─────────────────────────────
+
+    #[test]
+    fn test_daily_focus_stats_correct_aggregation() {
+        let pool = setup_pool();
+        let ts = today_ts();
+        let date = today_date();
+        insert_session(&pool, "s1", ts);
+        insert_activity_with_domain(&pool, "s1", "Chrome", None, "Focus", 120, ts);
+        insert_activity_with_domain(&pool, "s1", "Slack", None, "Neutral", 60, ts + 120);
+        insert_activity_with_domain(&pool, "s1", "YouTube", None, "Distraction", 30, ts + 180);
+
+        let stats = activity::query_daily_focus_stats(&pool, &date).unwrap();
+        assert_eq!(stats.focus_secs, 120);
+        assert_eq!(stats.neutral_secs, 60);
+        assert_eq!(stats.distraction_secs, 30);
+        assert_eq!(stats.total_secs, 210);
+    }
+
+    #[test]
+    fn test_daily_focus_stats_empty_returns_zeros() {
+        let pool = setup_pool();
+        let (yesterday_date, _) = yesterday();
+        let stats = activity::query_daily_focus_stats(&pool, &yesterday_date).unwrap();
+        assert_eq!(stats.total_secs, 0);
+        assert_eq!(stats.focus_secs, 0);
+    }
+
+    #[test]
+    fn test_daily_focus_stats_different_days_isolated() {
+        let pool = setup_pool();
+        let ts_today = today_ts();
+        let (yesterday_date, ts_yesterday) = yesterday();
+        let today_date = today_date();
+
+        // 날짜가 같으면 테스트 무의미
+        if today_date == yesterday_date {
+            return;
+        }
+
+        insert_session(&pool, "s1", ts_today);
+        insert_session(&pool, "s2", ts_yesterday);
+        insert_activity_with_domain(&pool, "s1", "Chrome", None, "Focus", 100, ts_today);
+        insert_activity_with_domain(&pool, "s2", "YouTube", None, "Distraction", 200, ts_yesterday);
+
+        let stats_today = activity::query_daily_focus_stats(&pool, &today_date).unwrap();
+        let stats_yesterday = activity::query_daily_focus_stats(&pool, &yesterday_date).unwrap();
+        assert_eq!(stats_today.focus_secs, 100);
+        assert_eq!(stats_yesterday.distraction_secs, 200);
+        assert_eq!(stats_today.distraction_secs, 0);
+    }
+}

--- a/src/App.css
+++ b/src/App.css
@@ -807,3 +807,282 @@ body {
   margin-top: 6px;
   text-align: right;
 }
+
+/* ── Settings 페이지 ─────────────────────────────────────────────────────── */
+
+.settings-page {
+  padding: 24px;
+  color: #e5e5ea;
+  background: #1c1c1e;
+  min-height: 100vh;
+  font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif;
+}
+
+.settings-title {
+  font-size: 18px;
+  font-weight: 600;
+  margin-bottom: 24px;
+  color: #fff;
+}
+
+.settings-section {
+  margin-bottom: 28px;
+  border-bottom: 1px solid rgba(255,255,255,0.06);
+  padding-bottom: 20px;
+}
+
+.settings-section:last-of-type {
+  border-bottom: none;
+}
+
+.settings-section-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: #aeaeb2;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-bottom: 8px;
+}
+
+.settings-desc {
+  font-size: 12px;
+  color: #636366;
+  margin-bottom: 12px;
+}
+
+.settings-shortcut-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.settings-shortcut-badge {
+  background: rgba(255,255,255,0.08);
+  border-radius: 6px;
+  padding: 5px 12px;
+  font-size: 13px;
+  font-family: "SF Mono", "Fira Code", monospace;
+  color: #e5e5ea;
+}
+
+.settings-shortcut-input {
+  background: rgba(255,255,255,0.08);
+  border: 1px solid rgba(255,255,255,0.15);
+  border-radius: 6px;
+  padding: 5px 12px;
+  font-size: 13px;
+  color: #e5e5ea;
+  outline: none;
+  min-width: 200px;
+}
+
+.settings-radio-group {
+  display: flex;
+  gap: 20px;
+  flex-wrap: wrap;
+}
+
+.settings-radio-label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.settings-rules-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 12px;
+  max-height: 180px;
+  overflow-y: auto;
+}
+
+.settings-rule-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px;
+  background: rgba(255,255,255,0.04);
+  border-radius: 6px;
+}
+
+.settings-rule-domain {
+  flex: 1;
+  font-size: 13px;
+}
+
+.settings-rule-badge {
+  font-size: 11px;
+  padding: 2px 8px;
+  border-radius: 4px;
+  font-weight: 500;
+}
+
+.settings-rule-badge--focus { background: rgba(48,209,88,0.15); color: #30d158; }
+.settings-rule-badge--distraction { background: rgba(255,69,58,0.15); color: #ff453a; }
+.settings-rule-badge--neutral { background: rgba(255,255,255,0.08); color: #aeaeb2; }
+
+.settings-rule-add {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.settings-input {
+  flex: 1;
+  background: rgba(255,255,255,0.08);
+  border: 1px solid rgba(255,255,255,0.12);
+  border-radius: 6px;
+  padding: 6px 10px;
+  font-size: 13px;
+  color: #e5e5ea;
+  outline: none;
+}
+
+.settings-input:focus {
+  border-color: #0a84ff;
+}
+
+.settings-select {
+  background: rgba(255,255,255,0.08);
+  border: 1px solid rgba(255,255,255,0.12);
+  border-radius: 6px;
+  padding: 6px 8px;
+  font-size: 13px;
+  color: #e5e5ea;
+  outline: none;
+  cursor: pointer;
+}
+
+.settings-btn-sm {
+  background: rgba(255,255,255,0.1);
+  border: none;
+  border-radius: 6px;
+  padding: 5px 12px;
+  font-size: 12px;
+  color: #e5e5ea;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.settings-btn-sm:hover { background: rgba(255,255,255,0.15); }
+
+.settings-btn-sm--danger {
+  background: rgba(255,69,58,0.12);
+  color: #ff453a;
+}
+.settings-btn-sm--danger:hover { background: rgba(255,69,58,0.2); }
+
+.settings-footer {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 12px;
+}
+
+.settings-save-btn {
+  background: #0a84ff;
+  border: none;
+  border-radius: 8px;
+  padding: 8px 24px;
+  font-size: 14px;
+  font-weight: 600;
+  color: #fff;
+  cursor: pointer;
+}
+
+.settings-save-btn:hover { background: #0076ea; }
+.settings-save-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+
+.settings-loading {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  color: #636366;
+  font-size: 13px;
+}
+
+/* ── SaveReferencePage (팝업 창) ─────────────────────────────────────────── */
+
+.save-ref-page {
+  padding: 20px;
+  background: #1c1c1e;
+  color: #e5e5ea;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif;
+}
+
+.save-ref-page-title {
+  font-size: 16px;
+  font-weight: 600;
+  color: #fff;
+  margin: 0;
+}
+
+.save-ref-page-url {
+  font-size: 11px;
+  color: #636366;
+  margin: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.save-ref-page-input {
+  background: rgba(255,255,255,0.08);
+  border: 1px solid rgba(255,255,255,0.12);
+  border-radius: 8px;
+  padding: 9px 12px;
+  font-size: 14px;
+  color: #e5e5ea;
+  outline: none;
+}
+
+.save-ref-page-input:focus {
+  border-color: #0a84ff;
+}
+
+.save-ref-page-actions {
+  display: flex;
+  gap: 8px;
+  margin-top: auto;
+}
+
+.save-ref-page-btn {
+  flex: 1;
+  background: rgba(255,255,255,0.1);
+  border: none;
+  border-radius: 8px;
+  padding: 10px 0;
+  font-size: 14px;
+  color: #e5e5ea;
+  cursor: pointer;
+}
+
+.save-ref-page-btn--primary {
+  background: #0a84ff;
+  color: #fff;
+  font-weight: 600;
+}
+
+.save-ref-page-btn--primary:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+/* ── Dropdown footer ──────────────────────────────────────────────────────── */
+
+.dd-footer {
+  display: flex;
+  gap: 6px;
+  padding: 0 12px 12px;
+}
+
+.dd-footer .dashboard-btn {
+  flex: 1;
+}

--- a/src/App.css
+++ b/src/App.css
@@ -1483,3 +1483,466 @@ body {
   font-weight: 600;
   cursor: pointer;
 }
+
+/* ── titleBarStyle: overlay — 트래픽 라이트 영역 패딩 & 드래그 ── */
+
+.dashboard {
+  padding-top: 28px;
+}
+
+.dash-header {
+  -webkit-app-region: drag;
+  padding-top: 8px;
+}
+
+.dash-header button,
+.dash-header input,
+.dash-header-actions {
+  -webkit-app-region: no-drag;
+}
+
+.settings-page {
+  padding-top: 44px;
+}
+
+.save-ref-page {
+  padding-top: 44px;
+}
+
+.onboarding {
+  padding-top: 44px;
+}
+
+/* ── 대시보드 헤더 액션 영역 ── */
+
+.dash-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+/* ── ErrorBoundary ── */
+
+.dash-error {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  padding: 48px 0;
+  color: #636366;
+  font-size: 13px;
+}
+
+/* ── Export 버튼 & 패널 ── */
+
+.export-trigger {
+  background: rgba(255,255,255,0.07);
+  border: 1px solid rgba(255,255,255,0.12);
+  border-radius: 8px;
+  color: #ebebf5cc;
+  font-size: 12px;
+  font-weight: 500;
+  padding: 5px 12px;
+  cursor: pointer;
+  transition: background 0.15s;
+  white-space: nowrap;
+}
+
+.export-trigger:hover {
+  background: rgba(255,255,255,0.12);
+}
+
+.export-panel {
+  position: relative;
+  background: #1c1c1e;
+  border: 1px solid rgba(255,255,255,0.1);
+  border-radius: 12px;
+  padding: 16px;
+  width: 280px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  box-shadow: 0 8px 32px rgba(0,0,0,0.6);
+  -webkit-app-region: no-drag;
+}
+
+.export-panel__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.export-panel__title {
+  font-size: 13px;
+  font-weight: 600;
+  color: #fff;
+}
+
+.export-panel__close {
+  background: transparent;
+  border: none;
+  color: #636366;
+  font-size: 14px;
+  cursor: pointer;
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+
+.export-panel__close:hover {
+  color: #ebebf5;
+  background: rgba(255,255,255,0.08);
+}
+
+.export-panel__row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.export-panel__label {
+  font-size: 12px;
+  color: #8e8e93;
+  width: 40px;
+  flex-shrink: 0;
+}
+
+.export-panel__input {
+  flex: 1;
+  background: rgba(255,255,255,0.07);
+  border: 1px solid rgba(255,255,255,0.1);
+  border-radius: 7px;
+  color: #ebebf5;
+  font-size: 12px;
+  padding: 5px 8px;
+  color-scheme: dark;
+}
+
+.export-panel__input:focus {
+  outline: none;
+  border-color: #0a84ff;
+}
+
+.export-panel__formats {
+  display: flex;
+  gap: 6px;
+}
+
+.export-format-btn {
+  background: rgba(255,255,255,0.06);
+  border: 1px solid rgba(255,255,255,0.1);
+  border-radius: 6px;
+  color: #8e8e93;
+  font-size: 11px;
+  font-weight: 600;
+  padding: 4px 10px;
+  cursor: pointer;
+  letter-spacing: 0.05em;
+  transition: all 0.15s;
+}
+
+.export-format-btn--active {
+  background: rgba(10,132,255,0.18);
+  border-color: #0a84ff;
+  color: #0a84ff;
+}
+
+.export-panel__btn {
+  background: #0a84ff;
+  border: none;
+  border-radius: 8px;
+  color: #fff;
+  font-size: 13px;
+  font-weight: 600;
+  padding: 8px 0;
+  cursor: pointer;
+  transition: opacity 0.15s;
+}
+
+.export-panel__btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.export-panel__success {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: rgba(48,209,88,0.12);
+  border: 1px solid rgba(48,209,88,0.25);
+  border-radius: 8px;
+  padding: 8px 10px;
+  font-size: 12px;
+  color: #30d158;
+}
+
+.export-panel__reveal {
+  background: transparent;
+  border: none;
+  color: #30d158;
+  font-size: 11px;
+  font-weight: 600;
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.export-panel__error {
+  font-size: 11px;
+  color: #ff453a;
+  margin: 0;
+  padding: 6px 8px;
+  background: rgba(255,69,58,0.1);
+  border-radius: 6px;
+}
+
+/* ── Weekly Report ── */
+
+.weekly-section {
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+}
+
+.weekly-section__block {
+  background: rgba(255,255,255,0.03);
+  border: 1px solid rgba(255,255,255,0.07);
+  border-radius: 12px;
+  padding: 16px 20px;
+}
+
+.weekly-section__subtitle {
+  font-size: 13px;
+  font-weight: 600;
+  color: #8e8e93;
+  margin: 0 0 14px;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+.weekly-report {
+  width: 100%;
+}
+
+.weekly-report__bars {
+  display: flex;
+  align-items: flex-end;
+  gap: 8px;
+  height: 100px;
+  padding-bottom: 24px;
+  position: relative;
+}
+
+.weekly-report__col {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  height: 100%;
+}
+
+.weekly-report__bar-wrap {
+  flex: 1;
+  width: 100%;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+}
+
+.weekly-report__bar {
+  width: 100%;
+  max-width: 36px;
+  min-height: 2px;
+  border-radius: 4px 4px 0 0;
+  transition: height 0.3s ease;
+}
+
+.weekly-report__day {
+  font-size: 11px;
+  color: #636366;
+  font-weight: 500;
+}
+
+.weekly-report__day.today {
+  color: #30d158;
+  font-weight: 700;
+}
+
+/* ── Trend Chart ── */
+
+.trend-section {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.trend-chart {
+  background: rgba(255,255,255,0.03);
+  border: 1px solid rgba(255,255,255,0.07);
+  border-radius: 12px;
+  padding: 16px 20px;
+}
+
+.trend-chart__header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+
+.trend-chart__title {
+  font-size: 13px;
+  font-weight: 600;
+  color: #ebebf5cc;
+}
+
+.trend-chart__avg {
+  font-size: 12px;
+  color: #0a84ff;
+  font-weight: 600;
+}
+
+.trend-chart__svg {
+  display: block;
+  border-radius: 6px;
+}
+
+/* ── Habit Insights ── */
+
+.habit-insights {
+  background: rgba(255,255,255,0.03);
+  border: 1px solid rgba(255,255,255,0.07);
+  border-radius: 12px;
+  padding: 16px 20px;
+}
+
+.habit-insights__title {
+  font-size: 13px;
+  font-weight: 600;
+  color: #8e8e93;
+  margin: 0 0 14px;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.habit-insights__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+  gap: 10px;
+  margin-bottom: 14px;
+}
+
+.habit-card {
+  background: rgba(255,255,255,0.05);
+  border: 1px solid rgba(255,255,255,0.08);
+  border-radius: 10px;
+  padding: 12px;
+  text-align: center;
+}
+
+.habit-card__value {
+  font-size: 22px;
+  font-weight: 700;
+  color: #fff;
+  line-height: 1.1;
+}
+
+.habit-card__label {
+  font-size: 11px;
+  color: #8e8e93;
+  margin-top: 4px;
+  line-height: 1.3;
+}
+
+.habit-card__sub {
+  font-size: 10px;
+  color: #48484a;
+  margin-top: 2px;
+}
+
+.habit-insights__best {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 12px;
+  background: rgba(10,132,255,0.1);
+  border: 1px solid rgba(10,132,255,0.2);
+  border-radius: 8px;
+}
+
+.habit-insights__best-label {
+  font-size: 11px;
+  color: #8e8e93;
+  flex-shrink: 0;
+}
+
+.habit-insights__best-date {
+  font-size: 12px;
+  color: #ebebf5cc;
+  flex: 1;
+}
+
+.habit-insights__best-pct {
+  font-size: 14px;
+  font-weight: 700;
+  color: #0a84ff;
+}
+
+/* ── Saved References 검색/태그 필터 ── */
+
+.saved-refs__filters {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-bottom: 12px;
+}
+
+.saved-refs__search {
+  width: 100%;
+  background: rgba(255,255,255,0.07);
+  border: 1px solid rgba(255,255,255,0.1);
+  border-radius: 9px;
+  color: #ebebf5;
+  font-size: 13px;
+  padding: 8px 12px;
+  box-sizing: border-box;
+  color-scheme: dark;
+  transition: border-color 0.15s;
+}
+
+.saved-refs__search:focus {
+  outline: none;
+  border-color: #0a84ff;
+}
+
+.saved-refs__search::placeholder {
+  color: #48484a;
+}
+
+.saved-refs__tags {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.saved-ref-tag--filter {
+  background: rgba(255,255,255,0.06);
+  border: 1px solid rgba(255,255,255,0.1);
+  border-radius: 20px;
+  padding: 3px 10px;
+  font-size: 11px;
+  color: #8e8e93;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.saved-ref-tag--filter:hover {
+  background: rgba(255,255,255,0.1);
+  color: #ebebf5;
+}
+
+.saved-ref-tag--filter.active {
+  background: rgba(10,132,255,0.18);
+  border-color: #0a84ff;
+  color: #0a84ff;
+}

--- a/src/App.css
+++ b/src/App.css
@@ -937,6 +937,17 @@ body.dark-bg {
 .settings-rule-badge--distraction { background: rgba(255,69,58,0.15); color: #ff453a; }
 .settings-rule-badge--neutral { background: rgba(255,255,255,0.08); color: #aeaeb2; }
 
+.settings-title-rule-keyword {
+  font-size: 12px;
+  color: #8e8e93;
+  font-style: italic;
+  flex-shrink: 0;
+  max-width: 140px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .settings-rule-add {
   display: flex;
   gap: 8px;

--- a/src/App.css
+++ b/src/App.css
@@ -1100,3 +1100,291 @@ body {
   color: #ff9f0a;
   line-height: 1.4;
 }
+
+/* ── Onboarding ──────────────────────────────────────────────────────────── */
+
+.onboarding {
+  background: #1c1c1e;
+  color: #fff;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  box-sizing: border-box;
+  font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif;
+  -webkit-font-smoothing: antialiased;
+}
+
+.onboarding__step {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  width: 100%;
+  max-width: 420px;
+  text-align: center;
+}
+
+.onboarding__icon {
+  font-size: 48px;
+}
+
+.onboarding__title {
+  font-size: 20px;
+  font-weight: 700;
+  margin: 0;
+}
+
+.onboarding__desc {
+  font-size: 13px;
+  color: #8e8e93;
+  margin: 0;
+  line-height: 1.5;
+}
+
+.onboarding__features {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  text-align: left;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.onboarding__features li {
+  font-size: 13px;
+  color: #ebebf5cc;
+}
+
+.onboarding__professions {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 100%;
+}
+
+.onboarding__profession {
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 10px;
+  padding: 12px 16px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s;
+  color: #fff;
+  text-align: left;
+}
+
+.onboarding__profession:hover {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.onboarding__profession--selected {
+  background: rgba(48, 209, 88, 0.15);
+  border-color: #30d158;
+}
+
+.onboarding__profession-label {
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.onboarding__profession-desc {
+  font-size: 11px;
+  color: #8e8e93;
+}
+
+.onboarding__actions {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 100%;
+}
+
+.onboarding__btn {
+  width: 100%;
+  padding: 12px;
+  border-radius: 10px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  border: none;
+  transition: opacity 0.15s;
+}
+
+.onboarding__btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.onboarding__btn--primary {
+  background: #30d158;
+  color: #000;
+}
+
+.onboarding__btn--ghost {
+  background: transparent;
+  color: #8e8e93;
+  font-weight: 400;
+}
+
+/* ── Quick Override ───────────────────────────────────────────────────────── */
+
+.quick-override {
+  background: rgba(44, 44, 46, 0.98);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 10px;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.quick-override__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.quick-override__domain {
+  font-size: 12px;
+  font-weight: 600;
+  color: #ebebf5cc;
+}
+
+.quick-override__close {
+  background: none;
+  border: none;
+  color: #8e8e93;
+  font-size: 16px;
+  cursor: pointer;
+  padding: 0 4px;
+  line-height: 1;
+}
+
+.quick-override__title {
+  font-size: 11px;
+  color: #8e8e93;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.quick-override__mode {
+  display: flex;
+  gap: 6px;
+}
+
+.quick-override__mode-btn {
+  flex: 1;
+  padding: 6px 8px;
+  border-radius: 7px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: transparent;
+  color: #8e8e93;
+  font-size: 11px;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+
+.quick-override__mode-btn.active {
+  background: rgba(255, 255, 255, 0.12);
+  color: #fff;
+}
+
+.quick-override__cats {
+  display: flex;
+  gap: 6px;
+}
+
+.quick-override__cat-btn {
+  flex: 1;
+  padding: 7px 6px;
+  border-radius: 7px;
+  background: transparent;
+  font-size: 11px;
+  font-weight: 600;
+  cursor: pointer;
+  border-width: 1px;
+  border-style: solid;
+  transition: background 0.15s;
+}
+
+.quick-override__cat-btn:hover {
+  background: rgba(255, 255, 255, 0.06);
+}
+
+/* ── dd-current-app override btn ─────────────────────────────────────────── */
+
+.dd-current-app__override-btn {
+  background: none;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  color: #8e8e93;
+  font-size: 10px;
+  border-radius: 5px;
+  padding: 2px 7px;
+  cursor: pointer;
+  margin-top: 4px;
+  transition: border-color 0.15s, color 0.15s;
+}
+
+.dd-current-app__override-btn:hover {
+  border-color: rgba(255, 255, 255, 0.3);
+  color: #fff;
+}
+
+/* ── AutoLaunch Toggle ────────────────────────────────────────────────────── */
+
+.settings-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  cursor: pointer;
+  gap: 12px;
+}
+
+.settings-toggle__label {
+  font-size: 13px;
+  color: #ebebf5;
+}
+
+.settings-toggle__input {
+  display: none;
+}
+
+.settings-toggle__slider {
+  position: relative;
+  display: inline-block;
+  width: 44px;
+  height: 24px;
+  background: #3a3a3c;
+  border-radius: 12px;
+  transition: background 0.2s;
+  flex-shrink: 0;
+}
+
+.settings-toggle__slider::after {
+  content: "";
+  position: absolute;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: #fff;
+  top: 2px;
+  left: 2px;
+  transition: transform 0.2s;
+}
+
+.settings-toggle__input:checked + .settings-toggle__slider {
+  background: #30d158;
+}
+
+.settings-toggle__input:checked + .settings-toggle__slider::after {
+  transform: translateX(20px);
+}

--- a/src/App.css
+++ b/src/App.css
@@ -1388,3 +1388,98 @@ body {
 .settings-toggle__input:checked + .settings-toggle__slider::after {
   transform: translateX(20px);
 }
+
+/* ── Goal Progress ────────────────────────────────────────────────────────── */
+
+.goal-progress {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.goal-progress__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.goal-progress__label {
+  font-size: 11px;
+  color: #8e8e93;
+  font-weight: 500;
+}
+
+.goal-progress__edit-btn {
+  background: none;
+  border: none;
+  color: #0a84ff;
+  font-size: 11px;
+  cursor: pointer;
+  padding: 0;
+}
+
+.goal-progress__bar-wrap {
+  height: 4px;
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+.goal-progress__bar {
+  height: 100%;
+  border-radius: 2px;
+  transition: width 0.4s ease;
+}
+
+.goal-progress__info {
+  display: flex;
+  gap: 4px;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.goal-progress__target {
+  color: #636366;
+  font-weight: 400;
+}
+
+.goal-progress__edit {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.goal-progress__presets {
+  display: flex;
+  gap: 4px;
+  flex: 1;
+}
+
+.goal-progress__preset {
+  flex: 1;
+  padding: 4px 0;
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  color: #8e8e93;
+  font-size: 11px;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.goal-progress__preset.active {
+  background: rgba(10, 132, 255, 0.2);
+  border-color: #0a84ff;
+  color: #0a84ff;
+}
+
+.goal-progress__save-btn {
+  padding: 4px 12px;
+  border-radius: 6px;
+  background: #0a84ff;
+  border: none;
+  color: #fff;
+  font-size: 11px;
+  font-weight: 600;
+  cursor: pointer;
+}

--- a/src/App.css
+++ b/src/App.css
@@ -1086,3 +1086,17 @@ body {
 .dd-footer .dashboard-btn {
   flex: 1;
 }
+
+/* ── 권한 안내 배너 ────────────────────────────────────────────────────────── */
+
+.dd-permission-banner {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 14px;
+  background: rgba(255, 159, 10, 0.15);
+  border-bottom: 1px solid rgba(255, 159, 10, 0.2);
+  font-size: 11px;
+  color: #ff9f0a;
+  line-height: 1.4;
+}

--- a/src/App.css
+++ b/src/App.css
@@ -271,3 +271,539 @@ body {
   display: flex;
   gap: 6px;
 }
+
+/* ── Dashboard ── */
+.dashboard {
+  min-height: 100vh;
+  background: #111;
+  color: #fff;
+  font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif;
+  -webkit-font-smoothing: antialiased;
+}
+
+.dash-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 20px 24px 12px;
+  border-bottom: 1px solid rgba(255,255,255,0.08);
+}
+
+.dash-title {
+  font-size: 20px;
+  font-weight: 700;
+  margin: 0;
+}
+
+.dash-date-nav {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  background: rgba(255,255,255,0.06);
+  border: 1px solid rgba(255,255,255,0.1);
+  border-radius: 10px;
+  padding: 2px;
+}
+
+.dash-date-btn {
+  background: transparent;
+  border: none;
+  color: #8e8e93;
+  font-size: 18px;
+  line-height: 1;
+  width: 28px;
+  height: 28px;
+  border-radius: 7px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.12s, color 0.12s;
+}
+
+.dash-date-btn:hover:not(:disabled) {
+  background: rgba(255,255,255,0.1);
+  color: #fff;
+}
+
+.dash-date-btn:disabled {
+  opacity: 0.25;
+  cursor: default;
+}
+
+.dash-date-label {
+  font-size: 13px;
+  font-weight: 500;
+  color: #fff;
+  min-width: 80px;
+  text-align: center;
+  padding: 0 4px;
+  user-select: none;
+}
+
+/* DatePicker 트리거 버튼 — dash-date-label 스타일 위에 추가 */
+.datepicker-trigger {
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  border-radius: 6px;
+  height: 28px;
+  transition: background 0.12s;
+}
+
+.datepicker-trigger:hover {
+  background: rgba(255,255,255,0.08);
+}
+
+/* DatePicker 팝업 */
+.datepicker-popup {
+  position: fixed;
+  z-index: 9999;
+  background: #1c1c1e;
+  border: 1px solid rgba(255,255,255,0.12);
+  border-radius: 14px;
+  padding: 12px;
+  width: 240px;
+  box-shadow: 0 16px 48px rgba(0,0,0,0.6);
+}
+
+.datepicker-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 10px;
+}
+
+.datepicker-month {
+  font-size: 14px;
+  font-weight: 600;
+  color: #fff;
+}
+
+.datepicker-nav {
+  background: transparent;
+  border: none;
+  color: #8e8e93;
+  font-size: 20px;
+  width: 28px;
+  height: 28px;
+  border-radius: 7px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.12s, color 0.12s;
+  padding: 0;
+  line-height: 1;
+}
+
+.datepicker-nav:hover:not(:disabled) {
+  background: rgba(255,255,255,0.1);
+  color: #fff;
+}
+
+.datepicker-nav:disabled {
+  opacity: 0.25;
+  cursor: default;
+}
+
+.datepicker-grid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 2px;
+}
+
+.datepicker-weekday {
+  font-size: 11px;
+  color: #636366;
+  text-align: center;
+  padding: 2px 0 6px;
+  font-weight: 500;
+}
+
+.datepicker-day {
+  background: transparent;
+  border: none;
+  color: #e5e5ea;
+  font-size: 13px;
+  width: 100%;
+  aspect-ratio: 1;
+  border-radius: 50%;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.1s, color 0.1s;
+  padding: 0;
+}
+
+.datepicker-day:hover:not(:disabled):not(.datepicker-day--selected) {
+  background: rgba(255,255,255,0.1);
+}
+
+.datepicker-day--today {
+  color: #3b82f6;
+  font-weight: 700;
+}
+
+.datepicker-day--selected {
+  background: #3b82f6;
+  color: #fff;
+  font-weight: 700;
+}
+
+.datepicker-day--selected:hover {
+  background: #2563eb;
+}
+
+.datepicker-day--disabled {
+  color: #3a3a3c;
+  cursor: default;
+}
+
+.dash-tabs {
+  display: flex;
+  gap: 4px;
+  padding: 12px 24px 0;
+}
+
+.dash-tab {
+  background: transparent;
+  border: none;
+  border-radius: 8px 8px 0 0;
+  padding: 8px 16px;
+  font-size: 13px;
+  color: #636366;
+  cursor: pointer;
+  transition: color 0.15s, background 0.15s;
+}
+
+.dash-tab:hover {
+  color: #fff;
+  background: rgba(255,255,255,0.05);
+}
+
+.dash-tab--active {
+  color: #fff;
+  background: rgba(255,255,255,0.08);
+}
+
+.dash-content {
+  padding: 20px 24px;
+}
+
+.dash-empty {
+  color: #636366;
+  font-size: 13px;
+  text-align: center;
+  padding: 40px 0;
+  margin: 0;
+}
+
+.dash-loading {
+  color: #636366;
+  font-size: 13px;
+  text-align: center;
+  padding: 40px 0;
+  margin: 0;
+}
+
+/* ── Activity Timeline ── */
+.timeline {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.timeline-item {
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
+}
+
+.timeline-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  margin-top: 4px;
+}
+
+.timeline-item--event .timeline-dot {
+  width: 16px;
+  height: 16px;
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  font-size: 8px;
+  margin-top: 0;
+}
+
+.timeline-event-label {
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.timeline-content {
+  flex: 1;
+  padding-bottom: 8px;
+  border-bottom: 1px solid rgba(255,255,255,0.05);
+}
+
+.timeline-item:last-child .timeline-content {
+  border-bottom: none;
+}
+
+.timeline-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+
+.timeline-app {
+  font-size: 13px;
+  font-weight: 600;
+  color: #fff;
+}
+
+.timeline-time {
+  font-size: 11px;
+  color: #636366;
+  font-variant-numeric: tabular-nums;
+}
+
+.timeline-domain {
+  font-size: 11px;
+  color: #8e8e93;
+  margin-top: 1px;
+}
+
+.timeline-duration {
+  font-size: 11px;
+  color: #636366;
+  margin-top: 2px;
+}
+
+/* ── Top Sites ── */
+.top-sites {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.site-row__header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 4px;
+}
+
+.site-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.site-domain {
+  flex: 1;
+  font-size: 13px;
+  color: #ebebf5cc;
+}
+
+.site-duration {
+  font-size: 12px;
+  color: #636366;
+  font-variant-numeric: tabular-nums;
+}
+
+.site-bar-bg {
+  height: 4px;
+  background: rgba(255,255,255,0.06);
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+.site-bar {
+  height: 100%;
+  border-radius: 2px;
+  opacity: 0.7;
+}
+
+/* ── Focus Score ── */
+.focus-score {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.focus-score__main {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.focus-score__pct {
+  font-size: 48px;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+
+.focus-score__label {
+  font-size: 16px;
+  color: #8e8e93;
+}
+
+.focus-score__bars {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.focus-score__bar-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.focus-score__bar-label {
+  font-size: 12px;
+  color: #636366;
+  width: 52px;
+}
+
+.focus-score__bar-bg {
+  flex: 1;
+  height: 6px;
+  background: rgba(255,255,255,0.06);
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.focus-score__bar {
+  height: 100%;
+  border-radius: 3px;
+  opacity: 0.8;
+}
+
+.focus-score__bar-time {
+  font-size: 12px;
+  color: #636366;
+  width: 52px;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.focus-score__total {
+  font-size: 13px;
+  color: #636366;
+  text-align: right;
+}
+
+/* ── Saved References ── */
+.saved-refs {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.saved-ref-item {
+  background: rgba(255,255,255,0.04);
+  border: 1px solid rgba(255,255,255,0.08);
+  border-radius: 10px;
+  padding: 12px;
+}
+
+.saved-ref-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.saved-ref-favicon {
+  flex-shrink: 0;
+  border-radius: 3px;
+}
+
+.saved-ref-title {
+  background: transparent;
+  border: none;
+  padding: 0;
+  font-size: 14px;
+  font-weight: 600;
+  color: #3b82f6;
+  cursor: pointer;
+  text-align: left;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.saved-ref-title:hover {
+  color: #60a5fa;
+}
+
+.saved-ref-controls {
+  display: flex;
+  gap: 4px;
+  flex-shrink: 0;
+  opacity: 0;
+  transition: opacity 0.15s;
+}
+
+.saved-ref-item:hover .saved-ref-controls {
+  opacity: 1;
+}
+
+.saved-ref-icon-btn {
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  padding: 2px 4px;
+  font-size: 13px;
+  line-height: 1;
+  border-radius: 4px;
+}
+
+.saved-ref-icon-btn:hover {
+  background: rgba(255,255,255,0.08);
+}
+
+.saved-ref-edit {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.saved-ref-actions {
+  display: flex;
+  gap: 6px;
+  margin-top: 2px;
+}
+
+.saved-ref-tags {
+  display: flex;
+  gap: 4px;
+  flex-wrap: wrap;
+  margin-top: 6px;
+}
+
+.saved-ref-tag {
+  background: rgba(255,255,255,0.08);
+  border-radius: 4px;
+  padding: 2px 7px;
+  font-size: 11px;
+  color: #8e8e93;
+}
+
+.saved-ref-date {
+  font-size: 11px;
+  color: #3a3a3c;
+  margin-top: 6px;
+  text-align: right;
+}

--- a/src/App.css
+++ b/src/App.css
@@ -5,10 +5,23 @@
   -webkit-font-smoothing: antialiased;
 }
 
+* {
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+*::-webkit-scrollbar {
+  display: none;
+}
+
 body {
   margin: 0;
   padding: 0;
   background: transparent;
+}
+
+body.dark-bg {
+  background: #111;
 }
 
 /* ── 드롭다운 컨테이너 ── */
@@ -1080,7 +1093,6 @@ body {
 .dd-footer {
   display: flex;
   gap: 6px;
-  padding: 0 12px 12px;
 }
 
 .dd-footer .dashboard-btn {
@@ -1487,6 +1499,14 @@ body {
 /* ── titleBarStyle: overlay — 트래픽 라이트 영역 패딩 & 드래그 ── */
 
 .dashboard {
+  padding-top: 0;
+}
+
+.dash-sticky-top {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background: #111;
   padding-top: 28px;
 }
 
@@ -1498,6 +1518,10 @@ body {
 .dash-header button,
 .dash-header input,
 .dash-header-actions {
+  -webkit-app-region: no-drag;
+}
+
+.dash-tabs {
   -webkit-app-region: no-drag;
 }
 
@@ -1942,6 +1966,38 @@ body {
 }
 
 .saved-ref-tag--filter.active {
+  background: rgba(10,132,255,0.18);
+  border-color: #0a84ff;
+  color: #0a84ff;
+}
+
+/* ── AppRuleSettings ── */
+
+.settings-empty {
+  font-size: 12px;
+  color: #48484a;
+  margin: 4px 0 8px;
+}
+
+.app-rule-source-toggle {
+  display: flex;
+  gap: 4px;
+  flex-shrink: 0;
+}
+
+.app-rule-toggle-btn {
+  background: rgba(255,255,255,0.06);
+  border: 1px solid rgba(255,255,255,0.1);
+  border-radius: 6px;
+  color: #8e8e93;
+  font-size: 11px;
+  padding: 4px 10px;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: all 0.15s;
+}
+
+.app-rule-toggle-btn.active {
   background: rgba(10,132,255,0.18);
   border-color: #0a84ff;
   color: #0a84ff;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,10 @@ import "./App.css";
 
 const windowLabel = getCurrentWindow().label;
 
+if (windowLabel !== "dropdown") {
+  document.body.classList.add("dark-bg");
+}
+
 function App() {
   if (windowLabel === "dashboard") return <Dashboard />;
   if (windowLabel === "settings") return <Settings />;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { Dropdown } from "./pages/Dropdown";
 import { Dashboard } from "./pages/Dashboard";
 import { Settings } from "./pages/Settings";
 import { SaveReferencePage } from "./pages/SaveReferencePage";
+import { Onboarding } from "./pages/Onboarding";
 import "./App.css";
 
 const windowLabel = getCurrentWindow().label;
@@ -11,6 +12,7 @@ function App() {
   if (windowLabel === "dashboard") return <Dashboard />;
   if (windowLabel === "settings") return <Settings />;
   if (windowLabel === "save-reference") return <SaveReferencePage />;
+  if (windowLabel === "onboarding") return <Onboarding />;
   return <Dropdown />;
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,16 @@
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { Dropdown } from "./pages/Dropdown";
 import { Dashboard } from "./pages/Dashboard";
+import { Settings } from "./pages/Settings";
+import { SaveReferencePage } from "./pages/SaveReferencePage";
 import "./App.css";
 
 const windowLabel = getCurrentWindow().label;
 
 function App() {
   if (windowLabel === "dashboard") return <Dashboard />;
+  if (windowLabel === "settings") return <Settings />;
+  if (windowLabel === "save-reference") return <SaveReferencePage />;
   return <Dropdown />;
 }
 

--- a/src/__tests__/components/Dashboard/ActivityTimeline.test.tsx
+++ b/src/__tests__/components/Dashboard/ActivityTimeline.test.tsx
@@ -1,0 +1,87 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ActivityTimeline } from "../../../components/Dashboard/ActivityTimeline";
+import type { Activity } from "../../../types/bindings";
+
+const ACTIVITIES: Activity[] = [
+  {
+    id: "a1",
+    session_id: "s1",
+    app_name: "Google Chrome",
+    url: "https://github.com",
+    domain: "github.com",
+    title: "GitHub",
+    classification: "Focus",
+    started_at: "2026-03-21T10:00:00Z",
+    duration_secs: 60,
+  },
+  {
+    id: "a2",
+    session_id: "s1",
+    app_name: "Slack",
+    url: null,
+    domain: null,
+    title: null,
+    classification: "Neutral",
+    started_at: "2026-03-21T10:01:00Z",
+    duration_secs: 30,
+  },
+  {
+    id: "a3",
+    session_id: "s1",
+    app_name: "YouTube",
+    url: "https://youtube.com/watch?v=xxx",
+    domain: "youtube.com",
+    title: "Some Video - YouTube",
+    classification: "Distraction",
+    started_at: "2026-03-21T10:01:30Z",
+    duration_secs: 45,
+  },
+];
+
+describe("ActivityTimeline", () => {
+  it("활동 목록을 렌더링", () => {
+    render(<ActivityTimeline activities={ACTIVITIES} sessionEvents={[]} />);
+    // title이 있으면 title을, 없으면 app_name 표시
+    expect(screen.getByText("GitHub")).toBeTruthy();
+    expect(screen.getByText("Slack")).toBeTruthy();
+    expect(screen.getByText("Some Video - YouTube")).toBeTruthy();
+  });
+
+  it("빈 상태 메시지 표시", () => {
+    render(<ActivityTimeline activities={[]} sessionEvents={[]} />);
+    expect(screen.getByText(/활동 없음|no activity/i)).toBeTruthy();
+  });
+
+  it("도메인 표시", () => {
+    render(<ActivityTimeline activities={ACTIVITIES} sessionEvents={[]} />);
+    expect(screen.getByText("github.com")).toBeTruthy();
+    expect(screen.getByText("youtube.com")).toBeTruthy();
+  });
+
+  it("classification별 색상 마커 렌더링", () => {
+    const { container } = render(<ActivityTimeline activities={ACTIVITIES} sessionEvents={[]} />);
+    const dots = container.querySelectorAll(".timeline-dot");
+    expect(dots.length).toBe(3);
+  });
+
+  it("duration 표시", () => {
+    render(<ActivityTimeline activities={ACTIVITIES} sessionEvents={[]} />);
+    // 60초 = "1분"
+    expect(screen.getByText("1분")).toBeTruthy();
+  });
+
+  it("세션 이벤트 렌더링", () => {
+    render(
+      <ActivityTimeline
+        activities={[]}
+        sessionEvents={[
+          { session_id: "s1", event_type: "start", timestamp: "2026-03-21T09:00:00Z" },
+          { session_id: "s1", event_type: "end", timestamp: "2026-03-21T11:00:00Z" },
+        ]}
+      />
+    );
+    expect(screen.getByText("세션 시작")).toBeTruthy();
+    expect(screen.getByText("세션 종료")).toBeTruthy();
+  });
+});

--- a/src/__tests__/components/Dashboard/TopSites.test.tsx
+++ b/src/__tests__/components/Dashboard/TopSites.test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { TopSites } from "../../../components/Dashboard/TopSites";
+import type { DomainSummary } from "../../../types/bindings";
+
+const SITES: DomainSummary[] = [
+  { domain: "github.com", total_secs: 3600, classification: "Focus" },
+  { domain: "youtube.com", total_secs: 1800, classification: "Distraction" },
+  { domain: "notion.so", total_secs: 900, classification: "Focus" },
+];
+
+describe("TopSites", () => {
+  it("도메인 목록 렌더링", () => {
+    render(<TopSites sites={SITES} />);
+    expect(screen.getByText("github.com")).toBeTruthy();
+    expect(screen.getByText("youtube.com")).toBeTruthy();
+    expect(screen.getByText("notion.so")).toBeTruthy();
+  });
+
+  it("빈 상태 메시지 표시", () => {
+    render(<TopSites sites={[]} />);
+    expect(screen.getByText(/사이트 없음|no sites/i)).toBeTruthy();
+  });
+
+  it("시간을 사람이 읽기 좋은 포맷으로 표시", () => {
+    render(<TopSites sites={SITES} />);
+    // 3600초 = "1h 00m" 또는 "60분"
+    expect(screen.getByText(/1h|60분|1시간/)).toBeTruthy();
+  });
+
+  it("classification별 색상 마커 렌더링", () => {
+    const { container } = render(<TopSites sites={SITES} />);
+    const dots = container.querySelectorAll(".site-dot");
+    expect(dots.length).toBe(3);
+  });
+
+  it("비율 바 렌더링", () => {
+    const { container } = render(<TopSites sites={SITES} />);
+    const bars = container.querySelectorAll(".site-bar");
+    expect(bars.length).toBe(3);
+  });
+});

--- a/src/__tests__/components/Dropdown.test.tsx
+++ b/src/__tests__/components/Dropdown.test.tsx
@@ -52,7 +52,12 @@ function setupIPC({
       case "get_focus_stats": return focusStats;
       case "get_top_apps": return topApps;
       case "get_current_app": return currentApp;
+      case "get_current_url": return null;
+      case "get_current_title": return null;
+      case "check_accessibility_permission": return true;
       case "open_dashboard": return undefined;
+      case "get_goal_progress": return { date: "2026-03-25", target_secs: 7200, actual_focus_secs: 0, progress_pct: 0 };
+      case "get_daily_goal": return { date: "2026-03-25", target_secs: 7200 };
       default: return undefined;
     }
   });

--- a/src/__tests__/components/Dropdown/QuickOverride.test.tsx
+++ b/src/__tests__/components/Dropdown/QuickOverride.test.tsx
@@ -1,0 +1,85 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { QuickOverride } from "../../../components/Dropdown/QuickOverride";
+
+vi.mock("../../../services/onboarding", () => ({
+  addTitleRule: vi.fn().mockResolvedValue({ id: 1, domain: "youtube.com", keyword: "tutorial", category: "Focus" }),
+}));
+
+const DEFAULT_PROPS = {
+  domain: "youtube.com",
+  title: "Rust Tutorial 2024",
+  currentCategory: "Distraction",
+  onClose: vi.fn(),
+};
+
+describe("QuickOverride", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("도메인과 타이틀이 표시된다", () => {
+    render(<QuickOverride {...DEFAULT_PROPS} />);
+    expect(screen.getByText("youtube.com")).toBeTruthy();
+    expect(screen.getByText("Rust Tutorial 2024")).toBeTruthy();
+  });
+
+  it("현재 분류(Distraction)는 버튼으로 표시되지 않는다", () => {
+    render(<QuickOverride {...DEFAULT_PROPS} />);
+    expect(screen.queryByRole("button", { name: /방해/ })).toBeNull();
+    expect(screen.getByRole("button", { name: /집중/ })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /기타/ })).toBeTruthy();
+  });
+
+  it("이번만 / 항상 이렇게 모드 버튼이 있다", () => {
+    render(<QuickOverride {...DEFAULT_PROPS} />);
+    expect(screen.getByText("이번만")).toBeTruthy();
+    expect(screen.getByText("항상 이렇게")).toBeTruthy();
+  });
+
+  it("기본 모드는 이번만이다", () => {
+    render(<QuickOverride {...DEFAULT_PROPS} />);
+    const onceBtn = screen.getByText("이번만");
+    expect(onceBtn.className).toContain("active");
+  });
+
+  it("항상 이렇게 모드에서 분류 변경 시 addTitleRule을 호출한다", async () => {
+    const { addTitleRule } = await import("../../../services/onboarding");
+    render(<QuickOverride {...DEFAULT_PROPS} />);
+
+    fireEvent.click(screen.getByText("항상 이렇게"));
+    fireEvent.click(screen.getByRole("button", { name: /집중/ }));
+
+    await waitFor(() => {
+      expect(addTitleRule).toHaveBeenCalledWith(
+        "youtube.com",
+        expect.any(String),
+        "Focus"
+      );
+    });
+  });
+
+  it("이번만 모드에서는 addTitleRule을 호출하지 않는다", async () => {
+    const { addTitleRule } = await import("../../../services/onboarding");
+    render(<QuickOverride {...DEFAULT_PROPS} />);
+
+    // 기본 모드 "이번만"
+    fireEvent.click(screen.getByRole("button", { name: /집중/ }));
+
+    await waitFor(() => {
+      expect(addTitleRule).not.toHaveBeenCalled();
+    });
+  });
+
+  it("닫기 버튼 클릭 시 onClose를 호출한다", () => {
+    const onClose = vi.fn();
+    render(<QuickOverride {...DEFAULT_PROPS} onClose={onClose} />);
+    fireEvent.click(screen.getByText("×"));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("domain이 null이면 현재 사이트로 표시된다", () => {
+    render(<QuickOverride {...DEFAULT_PROPS} domain={null} />);
+    expect(screen.getByText("현재 사이트")).toBeTruthy();
+  });
+});

--- a/src/__tests__/components/SaveReference.test.tsx
+++ b/src/__tests__/components/SaveReference.test.tsx
@@ -31,6 +31,9 @@ describe("SaveReference", () => {
   });
 
   it("버튼 클릭 시 폼 표시", async () => {
+    mockIPC((cmd) => {
+      if (cmd === "get_current_title") return null;
+    });
     render(<SaveReference currentUrl="https://github.com" />);
     fireEvent.click(screen.getByRole("button", { name: /reference 저장/i }));
     await waitFor(() => {
@@ -38,15 +41,22 @@ describe("SaveReference", () => {
     });
   });
 
-  it("폼에 URL이 자동으로 채워짐", async () => {
+  it("폼 열릴 때 get_current_title로 타이틀 자동 채움", async () => {
+    mockIPC((cmd) => {
+      if (cmd === "get_current_title") return "GitHub";
+    });
     render(<SaveReference currentUrl="https://github.com" />);
     fireEvent.click(screen.getByRole("button", { name: /reference 저장/i }));
     await waitFor(() => {
-      expect(screen.getByDisplayValue("https://github.com")).toBeTruthy();
+      const input = screen.getByPlaceholderText("제목 입력") as HTMLInputElement;
+      expect(input.value).toBe("GitHub");
     });
   });
 
   it("제목 없이 저장 버튼 클릭 시 저장 안 됨", async () => {
+    mockIPC((cmd) => {
+      if (cmd === "get_current_title") return null;
+    });
     const saved = vi.fn();
     render(<SaveReference currentUrl="https://github.com" onSaved={saved} />);
     fireEvent.click(screen.getByRole("button", { name: /reference 저장/i }));
@@ -57,6 +67,7 @@ describe("SaveReference", () => {
 
   it("제목 입력 후 저장 시 save_reference 커맨드 호출", async () => {
     mockIPC((cmd) => {
+      if (cmd === "get_current_title") return null;
       if (cmd === "save_reference") return REFERENCE_MOCK;
     });
     const onSaved = vi.fn();
@@ -77,6 +88,7 @@ describe("SaveReference", () => {
 
   it("저장 후 폼이 닫힘", async () => {
     mockIPC((cmd) => {
+      if (cmd === "get_current_title") return null;
       if (cmd === "save_reference") return REFERENCE_MOCK;
     });
     render(<SaveReference currentUrl="https://github.com" />);
@@ -95,6 +107,9 @@ describe("SaveReference", () => {
   });
 
   it("취소 버튼 클릭 시 폼 닫힘", async () => {
+    mockIPC((cmd) => {
+      if (cmd === "get_current_title") return null;
+    });
     render(<SaveReference currentUrl="https://github.com" />);
     fireEvent.click(screen.getByRole("button", { name: /reference 저장/i }));
     await waitFor(() => screen.getByPlaceholderText("제목 입력"));

--- a/src/__tests__/pages/Onboarding.test.tsx
+++ b/src/__tests__/pages/Onboarding.test.tsx
@@ -1,0 +1,95 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Onboarding } from "../../pages/Onboarding";
+
+vi.mock("../../services/onboarding", () => ({
+  applyProfessionRules: vi.fn().mockResolvedValue(undefined),
+  completeOnboarding: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@tauri-apps/api/window", () => ({
+  getCurrentWindow: () => ({
+    close: vi.fn().mockResolvedValue(undefined),
+    hide: vi.fn().mockResolvedValue(undefined),
+  }),
+}));
+
+describe("Onboarding", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("Welcome 화면이 처음에 표시된다", () => {
+    render(<Onboarding />);
+    expect(screen.getByText(/환영합니다/)).toBeTruthy();
+    expect(screen.getByText("시작하기")).toBeTruthy();
+    expect(screen.getByText("건너뛰기")).toBeTruthy();
+  });
+
+  it("시작하기 버튼 클릭 시 직업 선택 화면으로 이동한다", () => {
+    render(<Onboarding />);
+    fireEvent.click(screen.getByText("시작하기"));
+    expect(screen.getByText("직업을 선택해주세요")).toBeTruthy();
+  });
+
+  it("직업 목록 5개가 표시된다", () => {
+    render(<Onboarding />);
+    fireEvent.click(screen.getByText("시작하기"));
+    expect(screen.getByText("개발자")).toBeTruthy();
+    expect(screen.getByText("디자이너")).toBeTruthy();
+    expect(screen.getByText("마케터")).toBeTruthy();
+    expect(screen.getByText("학생")).toBeTruthy();
+    expect(screen.getByText(/기타/)).toBeTruthy();
+  });
+
+  it("직업 선택 후 다음 버튼이 활성화된다", () => {
+    render(<Onboarding />);
+    fireEvent.click(screen.getByText("시작하기"));
+
+    const nextBtn = screen.getByText("다음");
+    expect(nextBtn).toHaveProperty("disabled", true);
+
+    fireEvent.click(screen.getByText("개발자"));
+    expect(nextBtn).toHaveProperty("disabled", false);
+  });
+
+  it("다음 클릭 시 applyProfessionRules를 호출하고 완료 화면으로 이동한다", async () => {
+    const { applyProfessionRules } = await import("../../services/onboarding");
+    render(<Onboarding />);
+    fireEvent.click(screen.getByText("시작하기"));
+    fireEvent.click(screen.getByText("개발자"));
+    fireEvent.click(screen.getByText("다음"));
+
+    await waitFor(() => {
+      expect(applyProfessionRules).toHaveBeenCalledWith("developer");
+      expect(screen.getByText("설정 완료!")).toBeTruthy();
+    });
+  });
+
+  it("건너뛰기 클릭 시 completeOnboarding을 호출한다", async () => {
+    const { completeOnboarding } = await import("../../services/onboarding");
+    render(<Onboarding />);
+    fireEvent.click(screen.getByText("건너뛰기"));
+
+    await waitFor(() => {
+      expect(completeOnboarding).toHaveBeenCalled();
+    });
+  });
+
+  it("완료 화면에서 시작하기 버튼으로 completeOnboarding 호출한다", async () => {
+    const { applyProfessionRules, completeOnboarding } = await import("../../services/onboarding");
+    render(<Onboarding />);
+    fireEvent.click(screen.getByText("시작하기"));
+    fireEvent.click(screen.getByText("개발자"));
+    fireEvent.click(screen.getByText("다음"));
+
+    await waitFor(() => expect(screen.getByText("설정 완료!")).toBeTruthy());
+
+    fireEvent.click(screen.getByText("시작하기"));
+
+    await waitFor(() => {
+      expect(applyProfessionRules).toHaveBeenCalledTimes(1);
+      expect(completeOnboarding).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/__tests__/pages/SaveReferencePage.test.tsx
+++ b/src/__tests__/pages/SaveReferencePage.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { mockIPC } from "@tauri-apps/api/mocks";
+import { SaveReferencePage } from "../../pages/SaveReferencePage";
+
+const REFERENCE_MOCK = {
+  id: "ref-1",
+  session_id: "sess-1",
+  url: "https://github.com",
+  title: "GitHub",
+  tags: [],
+  created_at: "2026-03-21T00:00:00Z",
+};
+
+vi.mock("@tauri-apps/api/window", () => ({
+  getCurrentWindow: () => ({ close: vi.fn() }),
+}));
+
+describe("SaveReferencePage (팝업 창 전용)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("폼이 렌더링됨", () => {
+    mockIPC((cmd) => {
+      if (cmd === "get_current_url") return "https://github.com";
+      if (cmd === "get_current_title") return "GitHub";
+    });
+    render(<SaveReferencePage />);
+    expect(screen.getByPlaceholderText(/제목/i)).toBeTruthy();
+    expect(screen.getByPlaceholderText(/태그/i)).toBeTruthy();
+  });
+
+  it("제목 없이 저장 불가", () => {
+    mockIPC((cmd) => {
+      if (cmd === "get_current_url") return "https://github.com";
+      if (cmd === "get_current_title") return null;
+    });
+    render(<SaveReferencePage />);
+    const saveBtn = screen.getByRole("button", { name: /저장/i });
+    expect((saveBtn as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("제목 입력 후 저장 버튼 활성화", async () => {
+    mockIPC((cmd) => {
+      if (cmd === "get_current_url") return "https://github.com";
+      if (cmd === "get_current_title") return null;
+    });
+    render(<SaveReferencePage />);
+    // loading 완료 대기
+    await waitFor(() => {
+      expect((screen.getByPlaceholderText(/제목/i) as HTMLInputElement).disabled).toBe(false);
+    });
+    const titleInput = screen.getByPlaceholderText(/제목/i);
+    fireEvent.change(titleInput, { target: { value: "My Ref" } });
+    const saveBtn = screen.getByRole("button", { name: /저장/i });
+    expect((saveBtn as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it("저장 성공 후 save_reference 커맨드 호출", async () => {
+    let called = false;
+    mockIPC((cmd) => {
+      if (cmd === "get_current_url") return "https://github.com";
+      if (cmd === "get_current_title") return "GitHub";
+      if (cmd === "save_reference") {
+        called = true;
+        return REFERENCE_MOCK;
+      }
+    });
+    render(<SaveReferencePage />);
+    await waitFor(() => {
+      const titleInput = screen.getByPlaceholderText(/제목/i);
+      expect((titleInput as HTMLInputElement).value).toBeTruthy();
+    });
+
+    const saveBtn = screen.getByRole("button", { name: /저장/i });
+    fireEvent.click(saveBtn);
+
+    await waitFor(() => {
+      expect(called).toBe(true);
+    });
+  });
+});

--- a/src/__tests__/pages/Settings.test.tsx
+++ b/src/__tests__/pages/Settings.test.tsx
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { mockIPC } from "@tauri-apps/api/mocks";
+import { Settings } from "../../pages/Settings";
+
+const SETTINGS_MOCK = {
+  retention_days: 30,
+  shortcut_save_ref: "CmdOrCtrl+Shift+R",
+};
+
+const RULES_MOCK = [
+  { id: 1, domain: "github.com", category: "Focus" },
+  { id: 2, domain: "youtube.com", category: "Distraction" },
+];
+
+describe("Settings 페이지", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIPC((cmd) => {
+      if (cmd === "get_settings") return SETTINGS_MOCK;
+      if (cmd === "get_classification_rules") return RULES_MOCK;
+      if (cmd === "update_settings") return null;
+      if (cmd === "add_classification_rule") return { id: 99, domain: "example.com", category: "Focus" };
+      if (cmd === "delete_classification_rule") return null;
+    });
+  });
+
+  it("설정 페이지가 렌더링됨", async () => {
+    render(<Settings />);
+    await waitFor(() => {
+      expect(screen.getByText(/보관 기간/i)).toBeTruthy();
+    });
+  });
+
+  it("현재 단축키가 표시됨", async () => {
+    render(<Settings />);
+    await waitFor(() => {
+      expect(screen.getByText("CmdOrCtrl+Shift+R")).toBeTruthy();
+    });
+  });
+
+  it("분류 규칙 목록이 표시됨", async () => {
+    render(<Settings />);
+    await waitFor(() => {
+      expect(screen.getByText("github.com")).toBeTruthy();
+      expect(screen.getByText("youtube.com")).toBeTruthy();
+    });
+  });
+
+  it("보관 기간 변경 후 저장 가능", async () => {
+    let savedSettings: unknown = null;
+    mockIPC((cmd, args) => {
+      if (cmd === "get_settings") return SETTINGS_MOCK;
+      if (cmd === "get_classification_rules") return RULES_MOCK;
+      if (cmd === "update_settings") {
+        savedSettings = (args as { settings: unknown }).settings;
+        return null;
+      }
+    });
+    render(<Settings />);
+    await waitFor(() => screen.getByText(/보관 기간/i));
+
+    const select7 = screen.getByRole("radio", { name: "7일" });
+    fireEvent.click(select7);
+
+    const saveBtn = screen.getByRole("button", { name: /저장/i });
+    fireEvent.click(saveBtn);
+
+    await waitFor(() => {
+      expect(savedSettings).toBeTruthy();
+      expect((savedSettings as { retention_days: number }).retention_days).toBe(7);
+    });
+  });
+
+  it("분류 규칙 삭제 버튼 존재", async () => {
+    render(<Settings />);
+    await waitFor(() => screen.getByText("github.com"));
+    const deleteBtns = screen.getAllByRole("button", { name: /삭제/i });
+    expect(deleteBtns.length).toBeGreaterThan(0);
+  });
+
+  it("새 분류 규칙 추가 폼 존재", async () => {
+    render(<Settings />);
+    await waitFor(() => screen.getByPlaceholderText(/도메인/i));
+    expect(screen.getByPlaceholderText(/도메인/i)).toBeTruthy();
+  });
+});

--- a/src/components/Dashboard/ActivityTimeline.tsx
+++ b/src/components/Dashboard/ActivityTimeline.tsx
@@ -1,0 +1,122 @@
+import type { Activity, Classification, SessionEvent } from "../../types/bindings";
+
+function classColor(cls: Classification): string {
+  if (cls === "Focus") return "#30d158";
+  if (cls === "Distraction") return "#ff453a";
+  return "#636366";
+}
+
+function formatDuration(secs: number | null): string {
+  if (!secs || secs <= 0) return "0초";
+  if (secs < 60) return `${secs}초`;
+  const m = Math.floor(secs / 60);
+  const s = secs % 60;
+  if (m < 60) return s > 0 ? `${m}분 ${s}초` : `${m}분`;
+  const h = Math.floor(m / 60);
+  const rm = m % 60;
+  return rm > 0 ? `${h}시간 ${rm}분` : `${h}시간`;
+}
+
+function formatTime(isoStr: string): string {
+  const d = new Date(isoStr);
+  return d.toLocaleTimeString("ko-KR", { hour: "2-digit", minute: "2-digit" });
+}
+
+type TimelineItem =
+  | { kind: "activity"; data: Activity }
+  | { kind: "event"; data: SessionEvent };
+
+function eventLabel(type: SessionEvent["event_type"]): string {
+  if (type === "start") return "세션 시작";
+  if (type === "end") return "세션 종료";
+  return "세션 비정상 종료";
+}
+
+function eventIcon(type: SessionEvent["event_type"]): string {
+  if (type === "start") return "▶";
+  if (type === "end") return "■";
+  return "⚠";
+}
+
+function eventColor(type: SessionEvent["event_type"]): string {
+  if (type === "start") return "#3b82f6";
+  if (type === "end") return "#8e8e93";
+  return "#ff9f0a";
+}
+
+interface Props {
+  activities: Activity[];
+  sessionEvents: SessionEvent[];
+}
+
+export function ActivityTimeline({ activities, sessionEvents }: Props) {
+  // 활동과 세션 이벤트를 합쳐서 시간 역순 정렬
+  const items: TimelineItem[] = [
+    ...activities.map((a) => ({ kind: "activity" as const, data: a, ts: a.started_at })),
+    ...sessionEvents.map((e) => ({ kind: "event" as const, data: e, ts: e.timestamp })),
+  ]
+    .sort((a, b) => new Date(b.ts).getTime() - new Date(a.ts).getTime())
+    .map(({ kind, data }) =>
+      kind === "activity"
+        ? { kind: "activity" as const, data: data as Activity }
+        : { kind: "event" as const, data: data as SessionEvent }
+    );
+
+  if (items.length === 0) {
+    return <p className="dash-empty">활동 없음</p>;
+  }
+
+  return (
+    <div className="timeline">
+      {items.map((item, idx) => {
+        if (item.kind === "event") {
+          const ev = item.data;
+          return (
+            <div key={`evt-${ev.session_id}-${ev.event_type}`} className="timeline-item timeline-item--event">
+              <span
+                className="timeline-dot"
+                style={{ background: eventColor(ev.event_type), fontSize: 10 }}
+              >
+                {eventIcon(ev.event_type)}
+              </span>
+              <div className="timeline-content">
+                <div className="timeline-header">
+                  <span className="timeline-event-label" style={{ color: eventColor(ev.event_type) }}>
+                    {eventLabel(ev.event_type)}
+                  </span>
+                  <span className="timeline-time">{formatTime(ev.timestamp)}</span>
+                </div>
+              </div>
+            </div>
+          );
+        }
+
+        const act = item.data;
+        const displayTitle = act.title || act.domain || act.app_name;
+        const showSubtitle = act.title && (act.domain || act.app_name !== act.domain);
+
+        return (
+          <div key={act.id ?? idx} className="timeline-item">
+            <span
+              className="timeline-dot"
+              style={{ background: classColor(act.classification) }}
+            />
+            <div className="timeline-content">
+              <div className="timeline-header">
+                <span className="timeline-app">{displayTitle}</span>
+                <span className="timeline-time">{formatTime(act.started_at)}</span>
+              </div>
+              {showSubtitle && (
+                <div className="timeline-domain">{act.domain ?? act.app_name}</div>
+              )}
+              {!act.title && act.domain && act.app_name !== act.domain && (
+                <div className="timeline-domain">{act.app_name}</div>
+              )}
+              <div className="timeline-duration">{formatDuration(act.duration_secs)}</div>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/Dashboard/DatePicker.tsx
+++ b/src/components/Dashboard/DatePicker.tsx
@@ -1,0 +1,171 @@
+import { useState, useRef, useEffect, useCallback } from "react";
+import { createPortal } from "react-dom";
+
+interface Props {
+  value: string;          // "YYYY-MM-DD"
+  max: string;            // "YYYY-MM-DD" — 이 날짜 이후 선택 불가
+  onChange: (date: string) => void;
+}
+
+function toYM(dateStr: string) {
+  const [y, m] = dateStr.split("-").map(Number);
+  return { year: y, month: m };
+}
+
+function daysInMonth(year: number, month: number) {
+  return new Date(year, month, 0).getDate();
+}
+
+function firstDayOfMonth(year: number, month: number) {
+  return (new Date(year, month - 1, 1).getDay() + 6) % 7; // Mon=0
+}
+
+function toDateStr(year: number, month: number, day: number) {
+  return `${year}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+}
+
+function shiftDate(dateStr: string, days: number): string {
+  const d = new Date(dateStr);
+  d.setDate(d.getDate() + days);
+  return d.toISOString().split("T")[0];
+}
+
+function formatLabel(value: string, max: string): string {
+  const yesterday = shiftDate(max, -1);
+  if (value === max) return "오늘";
+  if (value === yesterday) return "어제";
+  const d = new Date(value);
+  return d.toLocaleDateString("ko-KR", { month: "long", day: "numeric", weekday: "short" });
+}
+
+const WEEK = ["월", "화", "수", "목", "금", "토", "일"];
+const POPUP_W = 240;
+
+export function DatePicker({ value, max, onChange }: Props) {
+  const [open, setOpen] = useState(false);
+  const [pos, setPos] = useState({ top: 0, left: 0 });
+  const [{ year, month }, setYM] = useState(() => toYM(value));
+  const triggerRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => { setYM(toYM(value)); }, [value]);
+
+  // 팝업 위치 계산 — 트리거 버튼 기준 fixed 좌표
+  const calcPos = useCallback(() => {
+    if (!triggerRef.current) return;
+    const r = triggerRef.current.getBoundingClientRect();
+    // 대시보드 헤더 우측 패딩(24px)에 맞춰 팝업 오른쪽 끝 고정
+    const left = window.innerWidth - POPUP_W - 48;
+    setPos({ top: r.bottom + 6, left });
+  }, []);
+
+  const handleOpen = () => {
+    calcPos();
+    setOpen((v) => !v);
+  };
+
+  // 외부 클릭 시 닫기
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      const target = e.target as Node;
+      if (triggerRef.current?.contains(target)) return;
+      // 팝업 내부 클릭은 팝업 자체에서 막으므로 여기선 닫기
+      setOpen(false);
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [open]);
+
+  const { year: maxY, month: maxM } = toYM(max);
+  const maxDay = Number(max.split("-")[2]);
+  const isMaxMonth = year === maxY && month === maxM;
+
+  function prevMonth() {
+    setYM(({ year: y, month: m }) =>
+      m === 1 ? { year: y - 1, month: 12 } : { year: y, month: m - 1 }
+    );
+  }
+
+  function nextMonth() {
+    if (isMaxMonth) return;
+    setYM(({ year: y, month: m }) =>
+      m === 12 ? { year: y + 1, month: 1 } : { year: y, month: m + 1 }
+    );
+  }
+
+  function isDisabled(day: number) {
+    if (year > maxY) return true;
+    if (year === maxY && month > maxM) return true;
+    if (year === maxY && month === maxM && day > maxDay) return true;
+    return false;
+  }
+
+  const totalDays = daysInMonth(year, month);
+  const startOffset = firstDayOfMonth(year, month);
+  const cells: (number | null)[] = [
+    ...Array(startOffset).fill(null),
+    ...Array.from({ length: totalDays }, (_, i) => i + 1),
+  ];
+  while (cells.length % 7 !== 0) cells.push(null);
+
+  const popup = open
+    ? createPortal(
+        <div
+          className="datepicker-popup"
+          style={{ top: pos.top, left: pos.left }}
+          onMouseDown={(e) => e.stopPropagation()}
+        >
+          <div className="datepicker-header">
+            <button className="datepicker-nav" onClick={prevMonth}>‹</button>
+            <span className="datepicker-month">{year}년 {month}월</span>
+            <button className="datepicker-nav" onClick={nextMonth} disabled={isMaxMonth}>›</button>
+          </div>
+
+          <div className="datepicker-grid">
+            {WEEK.map((w) => (
+              <span key={w} className="datepicker-weekday">{w}</span>
+            ))}
+            {cells.map((day, idx) => {
+              if (!day) return <span key={`e-${idx}`} />;
+              const disabled = isDisabled(day);
+              const selected = value === toDateStr(year, month, day);
+              const today = max === toDateStr(year, month, day);
+              return (
+                <button
+                  key={day}
+                  className={[
+                    "datepicker-day",
+                    selected ? "datepicker-day--selected" : "",
+                    today && !selected ? "datepicker-day--today" : "",
+                    disabled ? "datepicker-day--disabled" : "",
+                  ].filter(Boolean).join(" ")}
+                  disabled={disabled}
+                  onClick={() => {
+                    onChange(toDateStr(year, month, day));
+                    setOpen(false);
+                  }}
+                >
+                  {day}
+                </button>
+              );
+            })}
+          </div>
+        </div>,
+        document.body
+      )
+    : null;
+
+  return (
+    <>
+      <button
+        ref={triggerRef}
+        className="dash-date-label datepicker-trigger"
+        onClick={handleOpen}
+        type="button"
+      >
+        {formatLabel(value, max)}
+      </button>
+      {popup}
+    </>
+  );
+}

--- a/src/components/Dashboard/ExportButton.tsx
+++ b/src/components/Dashboard/ExportButton.tsx
@@ -1,0 +1,121 @@
+import { useState } from "react";
+import { exportData, type ExportFormat } from "../../services/export";
+import { openPath } from "@tauri-apps/plugin-opener";
+
+function todayStr(): string {
+  return new Date().toISOString().split("T")[0];
+}
+
+function thirtyDaysAgoStr(): string {
+  const d = new Date();
+  d.setDate(d.getDate() - 30);
+  return d.toISOString().split("T")[0];
+}
+
+export function ExportButton() {
+  const [open, setOpen] = useState(false);
+  const [startDate, setStartDate] = useState(thirtyDaysAgoStr);
+  const [endDate, setEndDate] = useState(todayStr);
+  const [format, setFormat] = useState<ExportFormat>("csv");
+  const [status, setStatus] = useState<"idle" | "loading" | "success" | "error">("idle");
+  const [savedPath, setSavedPath] = useState("");
+  const [errorMsg, setErrorMsg] = useState("");
+
+  async function handleExport() {
+    setStatus("loading");
+    setErrorMsg("");
+    try {
+      const path = await exportData(startDate, endDate, format);
+      setSavedPath(path);
+      setStatus("success");
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : String(e);
+      setErrorMsg(msg);
+      setStatus("error");
+    }
+  }
+
+  function handleReveal() {
+    // Open the folder containing the file
+    const dir = savedPath.substring(0, savedPath.lastIndexOf("/"));
+    openPath(dir).catch(() => openPath(savedPath));
+  }
+
+  if (!open) {
+    return (
+      <button className="export-trigger" onClick={() => { setOpen(true); setStatus("idle"); }}>
+        ↓ 내보내기
+      </button>
+    );
+  }
+
+  return (
+    <div className="export-panel">
+      <div className="export-panel__header">
+        <span className="export-panel__title">데이터 내보내기</span>
+        <button className="export-panel__close" onClick={() => { setOpen(false); setStatus("idle"); }}>
+          ✕
+        </button>
+      </div>
+
+      <div className="export-panel__row">
+        <label className="export-panel__label">시작일</label>
+        <input
+          type="date"
+          className="export-panel__input"
+          value={startDate}
+          max={endDate}
+          onChange={(e) => setStartDate(e.target.value)}
+        />
+      </div>
+
+      <div className="export-panel__row">
+        <label className="export-panel__label">종료일</label>
+        <input
+          type="date"
+          className="export-panel__input"
+          value={endDate}
+          min={startDate}
+          max={todayStr()}
+          onChange={(e) => setEndDate(e.target.value)}
+        />
+      </div>
+
+      <div className="export-panel__row">
+        <label className="export-panel__label">형식</label>
+        <div className="export-panel__formats">
+          {(["csv", "json"] as ExportFormat[]).map((f) => (
+            <button
+              key={f}
+              className={`export-format-btn${format === f ? " export-format-btn--active" : ""}`}
+              onClick={() => setFormat(f)}
+            >
+              {f.toUpperCase()}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {status === "success" && (
+        <div className="export-panel__success">
+          <span>저장 완료</span>
+          <button className="export-panel__reveal" onClick={handleReveal}>
+            폴더 열기
+          </button>
+        </div>
+      )}
+
+      {status === "error" && (
+        <p className="export-panel__error">{errorMsg}</p>
+      )}
+
+      <button
+        className="export-panel__btn"
+        onClick={handleExport}
+        disabled={status === "loading"}
+      >
+        {status === "loading" ? "내보내는 중…" : "내보내기"}
+      </button>
+    </div>
+  );
+}

--- a/src/components/Dashboard/FocusScore.tsx
+++ b/src/components/Dashboard/FocusScore.tsx
@@ -1,0 +1,67 @@
+import type { FocusMetrics } from "../../types/bindings";
+
+function formatDuration(secs: number): string {
+  if (secs < 60) return `${secs}초`;
+  const m = Math.floor(secs / 60);
+  if (m < 60) return `${m}분`;
+  const h = Math.floor(m / 60);
+  const rm = m % 60;
+  return rm > 0 ? `${h}h ${String(rm).padStart(2, "0")}m` : `${h}h 00m`;
+}
+
+interface Props {
+  metrics: FocusMetrics | null;
+}
+
+export function FocusScore({ metrics }: Props) {
+  if (!metrics || metrics.total_secs === 0) {
+    return <p className="dash-empty">데이터 없음</p>;
+  }
+
+  return (
+    <div className="focus-score">
+      <div className="focus-score__main">
+        <span
+          className="focus-score__pct"
+          style={{ color: "#30d158" }}
+        >
+          {Math.round(metrics.focus_percentage)}%
+        </span>
+        <span className="focus-score__label">집중</span>
+      </div>
+      <div className="focus-score__bars">
+        <div className="focus-score__bar-row">
+          <span className="focus-score__bar-label">Focus</span>
+          <div className="focus-score__bar-bg">
+            <div
+              className="focus-score__bar"
+              style={{ width: `${metrics.focus_percentage}%`, background: "#30d158" }}
+            />
+          </div>
+          <span className="focus-score__bar-time">{formatDuration(metrics.focus_secs)}</span>
+        </div>
+        <div className="focus-score__bar-row">
+          <span className="focus-score__bar-label">Neutral</span>
+          <div className="focus-score__bar-bg">
+            <div
+              className="focus-score__bar"
+              style={{ width: `${metrics.neutral_percentage}%`, background: "#636366" }}
+            />
+          </div>
+          <span className="focus-score__bar-time">{formatDuration(metrics.neutral_secs)}</span>
+        </div>
+        <div className="focus-score__bar-row">
+          <span className="focus-score__bar-label">Distract</span>
+          <div className="focus-score__bar-bg">
+            <div
+              className="focus-score__bar"
+              style={{ width: `${metrics.distraction_percentage}%`, background: "#ff453a" }}
+            />
+          </div>
+          <span className="focus-score__bar-time">{formatDuration(metrics.distraction_secs)}</span>
+        </div>
+      </div>
+      <div className="focus-score__total">총 {formatDuration(metrics.total_secs)}</div>
+    </div>
+  );
+}

--- a/src/components/Dashboard/HabitInsights.tsx
+++ b/src/components/Dashboard/HabitInsights.tsx
@@ -1,0 +1,110 @@
+import { useEffect, useState } from "react";
+import { getTrend, type TrendPoint } from "../../services/stats";
+
+const DAY_KR = ["일", "월", "화", "수", "목", "금", "토"];
+
+function formatHours(secs: number): string {
+  const h = Math.floor(secs / 3600);
+  const m = Math.floor((secs % 3600) / 60);
+  if (h === 0) return `${m}분`;
+  return m > 0 ? `${h}시간 ${m}분` : `${h}시간`;
+}
+
+function analyzeInsights(points: TrendPoint[]) {
+  if (points.length === 0) return null;
+
+  // Average focus %
+  const avgPct = points.reduce((s, p) => s + p.focus_pct, 0) / points.length;
+
+  // Best & worst day
+  const best = points.reduce((a, b) => (a.focus_pct > b.focus_pct ? a : b));
+  const worst = points.reduce((a, b) => (a.focus_pct < b.focus_pct ? a : b));
+
+  // Day-of-week aggregation
+  const dayBuckets: { sum: number; count: number }[] = Array.from(
+    { length: 7 },
+    () => ({ sum: 0, count: 0 })
+  );
+  for (const p of points) {
+    const dow = new Date(p.date).getDay();
+    dayBuckets[dow].sum += p.focus_pct;
+    dayBuckets[dow].count += 1;
+  }
+  const dayAvg = dayBuckets.map((b) => (b.count > 0 ? b.sum / b.count : -1));
+  const validDays = dayAvg.map((a, i) => ({ avg: a, i })).filter((d) => d.avg >= 0);
+  const bestDow = validDays.length > 0
+    ? validDays.reduce((a, b) => (a.avg > b.avg ? a : b))
+    : null;
+
+  // Current streak (consecutive days with focus_pct >= 50)
+  let streak = 0;
+  for (let i = points.length - 1; i >= 0; i--) {
+    if (points[i].focus_pct >= 50) streak++;
+    else break;
+  }
+
+  // Total focus time
+  const totalFocusSecs = points.reduce((s, p) => s + p.focus_secs, 0);
+
+  return { avgPct, best, worst, bestDow, streak, totalFocusSecs };
+}
+
+export function HabitInsights() {
+  const [points, setPoints] = useState<TrendPoint[]>([]);
+
+  useEffect(() => {
+    getTrend(30).then(setPoints);
+  }, []);
+
+  const insights = analyzeInsights(points);
+
+  if (!insights) {
+    return <p className="dash-empty">최근 30일 데이터가 없습니다</p>;
+  }
+
+  const { avgPct, best, bestDow, streak, totalFocusSecs } = insights;
+
+  return (
+    <div className="habit-insights">
+      <h3 className="habit-insights__title">30일 패턴 분석</h3>
+
+      <div className="habit-insights__grid">
+        <div className="habit-card">
+          <div className="habit-card__value">{avgPct.toFixed(0)}%</div>
+          <div className="habit-card__label">평균 Focus율</div>
+        </div>
+
+        <div className="habit-card">
+          <div className="habit-card__value">{formatHours(totalFocusSecs)}</div>
+          <div className="habit-card__label">총 집중 시간</div>
+        </div>
+
+        <div className="habit-card">
+          <div className="habit-card__value">{streak}일</div>
+          <div className="habit-card__label">Focus 연속 달성</div>
+          <div className="habit-card__sub">(50% 이상)</div>
+        </div>
+
+        {bestDow && (
+          <div className="habit-card">
+            <div className="habit-card__value">{DAY_KR[bestDow.i]}요일</div>
+            <div className="habit-card__label">가장 집중한 요일</div>
+            <div className="habit-card__sub">{bestDow.avg.toFixed(0)}% 평균</div>
+          </div>
+        )}
+      </div>
+
+      {best.focus_pct > 0 && (
+        <div className="habit-insights__best">
+          <span className="habit-insights__best-label">최고 기록</span>
+          <span className="habit-insights__best-date">
+            {new Date(best.date).toLocaleDateString("ko-KR")}
+          </span>
+          <span className="habit-insights__best-pct">
+            {best.focus_pct.toFixed(0)}%
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/Dashboard/SavedReferences.tsx
+++ b/src/components/Dashboard/SavedReferences.tsx
@@ -1,0 +1,163 @@
+import { useState } from "react";
+import { openUrl } from "@tauri-apps/plugin-opener";
+import type { Reference } from "../../types/bindings";
+import { deleteReference, updateReference } from "../../services/reference";
+
+interface Props {
+  references: Reference[];
+  onRefresh: () => void;
+}
+
+function faviconUrl(url: string): string {
+  try {
+    const hostname = new URL(url).hostname.replace(/^www\./, "");
+    return `https://www.google.com/s2/favicons?domain=${hostname}&sz=32`;
+  } catch {
+    return "";
+  }
+}
+
+interface EditState {
+  id: string;
+  title: string;
+  tags: string;
+}
+
+export function SavedReferences({ references, onRefresh }: Props) {
+  const [editing, setEditing] = useState<EditState | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  const handleOpen = async (url: string) => {
+    try {
+      await openUrl(url);
+    } catch {
+      // 실패 시 무시
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    try {
+      await deleteReference(id);
+      onRefresh();
+    } catch {
+      // 실패 시 무시
+    }
+  };
+
+  const handleEditStart = (ref: Reference) => {
+    setEditing({ id: ref.id, title: ref.title, tags: ref.tags.join(", ") });
+  };
+
+  const handleEditSave = async () => {
+    if (!editing || !editing.title.trim()) return;
+    setSaving(true);
+    try {
+      const tagList = editing.tags.trim()
+        ? editing.tags.split(",").map((t) => t.trim()).filter(Boolean)
+        : [];
+      await updateReference({ id: editing.id, title: editing.title.trim(), tags: tagList });
+      setEditing(null);
+      onRefresh();
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (references.length === 0) {
+    return <p className="dash-empty">저장된 Reference 없음</p>;
+  }
+
+  return (
+    <div className="saved-refs">
+      {references.map((ref) => {
+        const isEditing = editing?.id === ref.id;
+        return (
+          <div key={ref.id} className="saved-ref-item">
+            {isEditing ? (
+              <div className="saved-ref-edit">
+                <input
+                  className="save-ref-form__input"
+                  value={editing.title}
+                  onChange={(e) => setEditing({ ...editing, title: e.target.value })}
+                  autoFocus
+                />
+                <input
+                  className="save-ref-form__input"
+                  placeholder="태그 (쉼표로 구분)"
+                  value={editing.tags}
+                  onChange={(e) => setEditing({ ...editing, tags: e.target.value })}
+                />
+                <div className="saved-ref-actions">
+                  <button
+                    className="session-btn session-btn--start"
+                    style={{ fontSize: 12, padding: "4px 10px" }}
+                    onClick={handleEditSave}
+                    disabled={saving || !editing.title.trim()}
+                  >
+                    저장
+                  </button>
+                  <button
+                    className="dashboard-btn"
+                    style={{ fontSize: 12, padding: "4px 10px" }}
+                    onClick={() => setEditing(null)}
+                  >
+                    취소
+                  </button>
+                </div>
+              </div>
+            ) : (
+              <>
+                <div className="saved-ref-header">
+                  <img
+                    className="saved-ref-favicon"
+                    src={faviconUrl(ref.url)}
+                    alt=""
+                    width={16}
+                    height={16}
+                    onError={(e) => {
+                      (e.currentTarget as HTMLImageElement).style.display = "none";
+                    }}
+                  />
+                  <button
+                    className="saved-ref-title"
+                    onClick={() => handleOpen(ref.url)}
+                  >
+                    {ref.title}
+                  </button>
+                  <div className="saved-ref-controls">
+                    <button
+                      className="saved-ref-icon-btn"
+                      onClick={() => handleEditStart(ref)}
+                      title="수정"
+                    >
+                      ✏️
+                    </button>
+                    <button
+                      className="saved-ref-icon-btn"
+                      onClick={() => handleDelete(ref.id)}
+                      title="삭제"
+                    >
+                      🗑️
+                    </button>
+                  </div>
+                </div>
+                {ref.tags.length > 0 && (
+                  <div className="saved-ref-tags">
+                    {ref.tags.map((tag) => (
+                      <span key={tag} className="saved-ref-tag">
+                        {tag}
+                      </span>
+                    ))}
+                  </div>
+                )}
+                <div className="saved-ref-date">
+                  {new Date(ref.created_at).toLocaleDateString("ko-KR")}
+                </div>
+              </>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/Dashboard/SavedReferences.tsx
+++ b/src/components/Dashboard/SavedReferences.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useMemo } from "react";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import type { Reference } from "../../types/bindings";
 import { deleteReference, updateReference } from "../../services/reference";
@@ -26,6 +26,27 @@ interface EditState {
 export function SavedReferences({ references, onRefresh }: Props) {
   const [editing, setEditing] = useState<EditState | null>(null);
   const [saving, setSaving] = useState(false);
+  const [search, setSearch] = useState("");
+  const [activeTag, setActiveTag] = useState<string | null>(null);
+
+  const allTags = useMemo(() => {
+    const set = new Set<string>();
+    for (const ref of references) {
+      for (const tag of ref.tags) set.add(tag);
+    }
+    return Array.from(set).sort();
+  }, [references]);
+
+  const filtered = useMemo(() => {
+    return references.filter((ref) => {
+      const matchesSearch =
+        !search ||
+        ref.title.toLowerCase().includes(search.toLowerCase()) ||
+        ref.url.toLowerCase().includes(search.toLowerCase());
+      const matchesTag = !activeTag || ref.tags.includes(activeTag);
+      return matchesSearch && matchesTag;
+    });
+  }, [references, search, activeTag]);
 
   const handleOpen = async (url: string) => {
     try {
@@ -69,7 +90,40 @@ export function SavedReferences({ references, onRefresh }: Props) {
 
   return (
     <div className="saved-refs">
-      {references.map((ref) => {
+      <div className="saved-refs__filters">
+        <input
+          className="saved-refs__search"
+          type="text"
+          placeholder="제목 또는 URL 검색..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+        />
+        {allTags.length > 0 && (
+          <div className="saved-refs__tags">
+            <button
+              className={`saved-ref-tag saved-ref-tag--filter${activeTag === null ? " active" : ""}`}
+              onClick={() => setActiveTag(null)}
+            >
+              전체
+            </button>
+            {allTags.map((tag) => (
+              <button
+                key={tag}
+                className={`saved-ref-tag saved-ref-tag--filter${activeTag === tag ? " active" : ""}`}
+                onClick={() => setActiveTag(activeTag === tag ? null : tag)}
+              >
+                {tag}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {filtered.length === 0 && (
+        <p className="dash-empty">검색 결과 없음</p>
+      )}
+
+      {filtered.map((ref) => {
         const isEditing = editing?.id === ref.id;
         return (
           <div key={ref.id} className="saved-ref-item">

--- a/src/components/Dashboard/TopSites.tsx
+++ b/src/components/Dashboard/TopSites.tsx
@@ -1,0 +1,54 @@
+import type { DomainSummary, Classification } from "../../types/bindings";
+
+function classColor(cls: Classification | string): string {
+  if (cls === "Focus") return "#30d158";
+  if (cls === "Distraction") return "#ff453a";
+  return "#636366";
+}
+
+function formatDuration(secs: number): string {
+  if (secs < 60) return `${secs}초`;
+  const m = Math.floor(secs / 60);
+  if (m < 60) return `${m}분`;
+  const h = Math.floor(m / 60);
+  const rm = m % 60;
+  return rm > 0 ? `${h}h ${String(rm).padStart(2, "0")}m` : `${h}h 00m`;
+}
+
+interface Props {
+  sites: DomainSummary[];
+}
+
+export function TopSites({ sites }: Props) {
+  if (sites.length === 0) {
+    return <p className="dash-empty">사이트 없음</p>;
+  }
+
+  const maxSecs = sites[0]?.total_secs ?? 1;
+
+  return (
+    <div className="top-sites">
+      {sites.map((site) => (
+        <div key={site.domain} className="site-row">
+          <div className="site-row__header">
+            <span
+              className="site-dot"
+              style={{ background: classColor(site.classification) }}
+            />
+            <span className="site-domain">{site.domain}</span>
+            <span className="site-duration">{formatDuration(site.total_secs)}</span>
+          </div>
+          <div className="site-bar-bg">
+            <div
+              className="site-bar"
+              style={{
+                width: `${(site.total_secs / maxSecs) * 100}%`,
+                background: classColor(site.classification),
+              }}
+            />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/Dashboard/TrendChart.tsx
+++ b/src/components/Dashboard/TrendChart.tsx
@@ -1,0 +1,145 @@
+import { useEffect, useState } from "react";
+import { getTrend, type TrendPoint } from "../../services/stats";
+
+function formatDate(dateStr: string): string {
+  const d = new Date(dateStr);
+  return `${d.getMonth() + 1}/${d.getDate()}`;
+}
+
+export function TrendChart() {
+  const [points, setPoints] = useState<TrendPoint[]>([]);
+
+  useEffect(() => {
+    getTrend(30).then(setPoints);
+  }, []);
+
+  if (points.length === 0) {
+    return <p className="dash-empty">최근 30일 데이터가 없습니다</p>;
+  }
+
+  const W = 560;
+  const H = 180;
+  const PAD = { top: 16, right: 16, bottom: 32, left: 36 };
+  const chartW = W - PAD.left - PAD.right;
+  const chartH = H - PAD.top - PAD.bottom;
+
+  const maxPct = 100;
+  const xStep = points.length > 1 ? chartW / (points.length - 1) : chartW;
+
+  const toX = (i: number) => PAD.left + i * xStep;
+  const toY = (pct: number) => PAD.top + chartH - (pct / maxPct) * chartH;
+
+  const polyline = points
+    .map((p, i) => `${toX(i)},${toY(p.focus_pct)}`)
+    .join(" ");
+
+  // area fill path
+  const areaPath = [
+    `M ${toX(0)},${toY(points[0].focus_pct)}`,
+    ...points.slice(1).map((p, i) => `L ${toX(i + 1)},${toY(p.focus_pct)}`),
+    `L ${toX(points.length - 1)},${PAD.top + chartH}`,
+    `L ${toX(0)},${PAD.top + chartH}`,
+    "Z",
+  ].join(" ");
+
+  // Y-axis ticks
+  const yTicks = [0, 25, 50, 75, 100];
+
+  // X-axis labels: show first, middle, last
+  const xLabelIndices = new Set([
+    0,
+    Math.floor((points.length - 1) / 2),
+    points.length - 1,
+  ]);
+
+  const avgPct =
+    points.reduce((s, p) => s + p.focus_pct, 0) / points.length;
+
+  return (
+    <div className="trend-chart">
+      <div className="trend-chart__header">
+        <span className="trend-chart__title">최근 30일 Focus 추이</span>
+        <span className="trend-chart__avg">평균 {avgPct.toFixed(0)}%</span>
+      </div>
+
+      <svg
+        viewBox={`0 0 ${W} ${H}`}
+        width="100%"
+        className="trend-chart__svg"
+      >
+        <defs>
+          <linearGradient id="trend-fill" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor="#0a84ff" stopOpacity="0.3" />
+            <stop offset="100%" stopColor="#0a84ff" stopOpacity="0" />
+          </linearGradient>
+        </defs>
+
+        {/* Y-axis grid lines */}
+        {yTicks.map((tick) => (
+          <g key={tick}>
+            <line
+              x1={PAD.left}
+              y1={toY(tick)}
+              x2={W - PAD.right}
+              y2={toY(tick)}
+              stroke="#333"
+              strokeWidth={0.5}
+              strokeDasharray="3,3"
+            />
+            <text
+              x={PAD.left - 6}
+              y={toY(tick) + 4}
+              textAnchor="end"
+              fontSize={9}
+              fill="#888"
+            >
+              {tick}%
+            </text>
+          </g>
+        ))}
+
+        {/* Area fill */}
+        <path d={areaPath} fill="url(#trend-fill)" />
+
+        {/* Line */}
+        <polyline
+          points={polyline}
+          fill="none"
+          stroke="#0a84ff"
+          strokeWidth={2}
+          strokeLinejoin="round"
+          strokeLinecap="round"
+        />
+
+        {/* Data points */}
+        {points.map((p, i) => (
+          <circle
+            key={p.date}
+            cx={toX(i)}
+            cy={toY(p.focus_pct)}
+            r={3}
+            fill="#0a84ff"
+          >
+            <title>{`${p.date}: ${p.focus_pct.toFixed(0)}%`}</title>
+          </circle>
+        ))}
+
+        {/* X-axis labels */}
+        {points.map((p, i) =>
+          xLabelIndices.has(i) ? (
+            <text
+              key={p.date}
+              x={toX(i)}
+              y={H - 4}
+              textAnchor="middle"
+              fontSize={9}
+              fill="#888"
+            >
+              {formatDate(p.date)}
+            </text>
+          ) : null
+        )}
+      </svg>
+    </div>
+  );
+}

--- a/src/components/Dashboard/WeeklyReport.tsx
+++ b/src/components/Dashboard/WeeklyReport.tsx
@@ -24,14 +24,18 @@ interface Props {
 
 export function WeeklyReport({ weekOffset = 0 }: Props) {
   const [stats, setStats] = useState<WeeklyDayStat[]>([]);
-  const [startDate, setStartDate] = useState("");
+  const [startDate, setStartDate] = useState(() => {
+    const base = new Date();
+    base.setDate(base.getDate() + weekOffset * 7);
+    return getMonday(base);
+  });
 
   useEffect(() => {
     const base = new Date();
     base.setDate(base.getDate() + weekOffset * 7);
     const monday = getMonday(base);
     setStartDate(monday);
-    getWeeklyReport(monday).then(setStats);
+    getWeeklyReport(monday).then(setStats).catch(() => setStats([]));
   }, [weekOffset]);
 
   // 7일 슬롯 생성 (데이터 없는 날은 0으로)

--- a/src/components/Dashboard/WeeklyReport.tsx
+++ b/src/components/Dashboard/WeeklyReport.tsx
@@ -1,0 +1,77 @@
+import { useEffect, useState } from "react";
+import { getWeeklyReport, type WeeklyDayStat } from "../../services/stats";
+
+const DAY_LABELS = ["월", "화", "수", "목", "금", "토", "일"];
+
+function getMonday(date: Date): string {
+  const d = new Date(date);
+  const day = d.getDay();
+  const diff = day === 0 ? -6 : 1 - day;
+  d.setDate(d.getDate() + diff);
+  return d.toISOString().slice(0, 10);
+}
+
+function formatHours(secs: number): string {
+  const h = Math.floor(secs / 3600);
+  const m = Math.floor((secs % 3600) / 60);
+  if (h === 0) return `${m}m`;
+  return m > 0 ? `${h}h ${m}m` : `${h}h`;
+}
+
+interface Props {
+  weekOffset?: number; // 0 = 이번주, -1 = 지난주
+}
+
+export function WeeklyReport({ weekOffset = 0 }: Props) {
+  const [stats, setStats] = useState<WeeklyDayStat[]>([]);
+  const [startDate, setStartDate] = useState("");
+
+  useEffect(() => {
+    const base = new Date();
+    base.setDate(base.getDate() + weekOffset * 7);
+    const monday = getMonday(base);
+    setStartDate(monday);
+    getWeeklyReport(monday).then(setStats);
+  }, [weekOffset]);
+
+  // 7일 슬롯 생성 (데이터 없는 날은 0으로)
+  const slots = Array.from({ length: 7 }, (_, i) => {
+    const d = new Date(startDate);
+    d.setDate(d.getDate() + i);
+    const dateStr = d.toISOString().slice(0, 10);
+    const found = stats.find((s) => s.date === dateStr);
+    return { label: DAY_LABELS[i], date: dateStr, focus_secs: found?.focus_secs ?? 0 };
+  });
+
+  const maxSecs = Math.max(...slots.map((s) => s.focus_secs), 1);
+  const today = new Date().toISOString().slice(0, 10);
+
+  return (
+    <div className="weekly-report">
+      <div className="weekly-report__bars">
+        {slots.map((slot) => {
+          const pct = (slot.focus_secs / maxSecs) * 100;
+          const isToday = slot.date === today;
+          return (
+            <div key={slot.date} className="weekly-report__col">
+              <div className="weekly-report__bar-wrap">
+                <div
+                  className="weekly-report__bar"
+                  style={{
+                    height: `${pct}%`,
+                    background: isToday ? "#30d158" : "#0a84ff",
+                    opacity: slot.focus_secs === 0 ? 0.2 : 1,
+                  }}
+                  title={slot.focus_secs > 0 ? formatHours(slot.focus_secs) : "기록 없음"}
+                />
+              </div>
+              <span className={`weekly-report__day${isToday ? " today" : ""}`}>
+                {slot.label}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/Dropdown/GoalProgress.tsx
+++ b/src/components/Dropdown/GoalProgress.tsx
@@ -1,0 +1,87 @@
+import { useEffect, useState } from "react";
+import { getDailyGoal, getGoalProgress, setDailyGoal, type GoalProgress as GoalProgressData } from "../../services/goal";
+
+const PRESET_HOURS = [1, 2, 3, 4, 6];
+
+function formatSecs(secs: number): string {
+  const h = Math.floor(secs / 3600);
+  const m = Math.floor((secs % 3600) / 60);
+  if (h > 0) return `${h}h ${m > 0 ? `${m}m` : ""}`.trim();
+  return `${m}m`;
+}
+
+export function GoalProgress() {
+  const [progress, setProgress] = useState<GoalProgressData | null>(null);
+  const [editing, setEditing] = useState(false);
+  const [selectedHours, setSelectedHours] = useState(2);
+
+  useEffect(() => {
+    getGoalProgress().then(setProgress);
+    getDailyGoal().then((g) => setSelectedHours(Math.round(g.target_secs / 3600)));
+  }, []);
+
+  const handleSave = async () => {
+    await setDailyGoal(selectedHours * 3600);
+    const updated = await getGoalProgress();
+    setProgress(updated);
+    setEditing(false);
+  };
+
+  if (!progress) return null;
+
+  const pct = Math.min(Math.round(progress.progress_pct), 100);
+  const isAchieved = pct >= 100;
+
+  return (
+    <div className="goal-progress">
+      <div className="goal-progress__header">
+        <span className="goal-progress__label">오늘 목표</span>
+        <button
+          className="goal-progress__edit-btn"
+          onClick={() => setEditing((v) => !v)}
+        >
+          {editing ? "취소" : "변경"}
+        </button>
+      </div>
+
+      {editing ? (
+        <div className="goal-progress__edit">
+          <div className="goal-progress__presets">
+            {PRESET_HOURS.map((h) => (
+              <button
+                key={h}
+                className={`goal-progress__preset${selectedHours === h ? " active" : ""}`}
+                onClick={() => setSelectedHours(h)}
+              >
+                {h}h
+              </button>
+            ))}
+          </div>
+          <button className="goal-progress__save-btn" onClick={handleSave}>
+            저장
+          </button>
+        </div>
+      ) : (
+        <>
+          <div className="goal-progress__bar-wrap">
+            <div
+              className="goal-progress__bar"
+              style={{
+                width: `${pct}%`,
+                background: isAchieved ? "#30d158" : "#0a84ff",
+              }}
+            />
+          </div>
+          <div className="goal-progress__info">
+            <span style={{ color: isAchieved ? "#30d158" : "#fff" }}>
+              {formatSecs(progress.actual_focus_secs)}
+            </span>
+            <span className="goal-progress__target">
+              / {formatSecs(progress.target_secs)} ({pct}%)
+            </span>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/Dropdown/QuickOverride.tsx
+++ b/src/components/Dropdown/QuickOverride.tsx
@@ -1,0 +1,83 @@
+import { useState } from "react";
+import { addTitleRule } from "../../services/onboarding";
+
+interface QuickOverrideProps {
+  domain: string | null;
+  title: string | null;
+  currentCategory: string;
+  onClose: () => void;
+}
+
+const CATEGORIES = [
+  { value: "Focus", label: "집중", color: "#30d158" },
+  { value: "Neutral", label: "기타", color: "#636366" },
+  { value: "Distraction", label: "방해", color: "#ff453a" },
+];
+
+export function QuickOverride({ domain, title, currentCategory, onClose }: QuickOverrideProps) {
+  const [mode, setMode] = useState<"once" | "always">("once");
+  const [loading, setLoading] = useState(false);
+
+  const handleApply = async (category: string) => {
+    if (loading) return;
+    setLoading(true);
+    try {
+      if (mode === "always" && domain && title) {
+        // 제목 키워드 기반 영구 규칙 생성
+        // 타이틀의 첫 번째 의미있는 단어를 keyword로 사용
+        const keyword = extractKeyword(title);
+        if (keyword) {
+          await addTitleRule(domain, keyword, category);
+        }
+      }
+      onClose();
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="quick-override">
+      <div className="quick-override__header">
+        <span className="quick-override__domain">{domain ?? "현재 사이트"}</span>
+        <button className="quick-override__close" onClick={onClose}>×</button>
+      </div>
+      {title && (
+        <div className="quick-override__title">{title}</div>
+      )}
+      <div className="quick-override__mode">
+        <button
+          className={`quick-override__mode-btn${mode === "once" ? " active" : ""}`}
+          onClick={() => setMode("once")}
+        >
+          이번만
+        </button>
+        <button
+          className={`quick-override__mode-btn${mode === "always" ? " active" : ""}`}
+          onClick={() => setMode("always")}
+        >
+          항상 이렇게
+        </button>
+      </div>
+      <div className="quick-override__cats">
+        {CATEGORIES.filter((c) => c.value !== currentCategory).map((cat) => (
+          <button
+            key={cat.value}
+            className="quick-override__cat-btn"
+            style={{ borderColor: cat.color, color: cat.color }}
+            onClick={() => handleApply(cat.value)}
+            disabled={loading}
+          >
+            {`${cat.label}로 변경`}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function extractKeyword(title: string): string {
+  // 타이틀에서 3글자 이상의 단어를 keyword로 추출
+  const words = title.split(/\s+/).filter((w) => w.length >= 3);
+  return words[0]?.toLowerCase() ?? "";
+}

--- a/src/components/Dropdown/SaveReference.tsx
+++ b/src/components/Dropdown/SaveReference.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import type { Reference } from "../../types/bindings";
-import { saveReference } from "../../services/reference";
+import { saveReference, getCurrentTitle } from "../../services/reference";
 
 interface SaveReferenceProps {
   currentUrl: string | null;
@@ -12,12 +12,21 @@ export function SaveReference({ currentUrl, onSaved }: SaveReferenceProps) {
   const [title, setTitle] = useState("");
   const [tags, setTags] = useState("");
   const [saving, setSaving] = useState(false);
+  const [loadingTitle, setLoadingTitle] = useState(false);
 
-  const handleOpen = () => {
+  const handleOpen = async () => {
     if (!currentUrl) return;
-    setTitle("");
     setTags("");
     setOpen(true);
+    setLoadingTitle(true);
+    try {
+      const pageTitle = await getCurrentTitle();
+      setTitle(pageTitle ?? "");
+    } catch {
+      setTitle("");
+    } finally {
+      setLoadingTitle(false);
+    }
   };
 
   const handleClose = () => {
@@ -48,16 +57,11 @@ export function SaveReference({ currentUrl, onSaved }: SaveReferenceProps) {
       <div className="save-ref-form">
         <input
           className="save-ref-form__input"
-          value={currentUrl ?? ""}
-          readOnly
-          style={{ color: "#636366", fontSize: 11 }}
-        />
-        <input
-          className="save-ref-form__input"
-          placeholder="제목 입력"
+          placeholder={loadingTitle ? "타이틀 불러오는 중..." : "제목 입력"}
           value={title}
           onChange={(e) => setTitle(e.target.value)}
-          autoFocus
+          disabled={loadingTitle}
+          autoFocus={!loadingTitle}
         />
         <input
           className="save-ref-form__input"
@@ -70,7 +74,7 @@ export function SaveReference({ currentUrl, onSaved }: SaveReferenceProps) {
             className="session-btn session-btn--start"
             style={{ flex: 1, padding: "7px 0", fontSize: 13 }}
             onClick={handleSave}
-            disabled={saving || !title.trim()}
+            disabled={saving || loadingTitle || !title.trim()}
           >
             저장
           </button>

--- a/src/components/Settings/AppRuleSettings.tsx
+++ b/src/components/Settings/AppRuleSettings.tsx
@@ -1,0 +1,140 @@
+import { useState, useEffect } from "react";
+import type { AppRule } from "../../types/bindings";
+import { getAppRules, addAppRule, deleteAppRule } from "../../services/settings";
+import { getTrackedApps } from "../../services/activity";
+
+const CATEGORIES = ["Focus", "Neutral", "Distraction"] as const;
+type Category = (typeof CATEGORIES)[number];
+
+export function AppRuleSettings() {
+  const [rules, setRules] = useState<AppRule[]>([]);
+  const [trackedApps, setTrackedApps] = useState<string[]>([]);
+  const [selectedApp, setSelectedApp] = useState("");
+  const [customApp, setCustomApp] = useState("");
+  const [category, setCategory] = useState<Category>("Focus");
+  const [adding, setAdding] = useState(false);
+  const [useCustom, setUseCustom] = useState(false);
+
+  useEffect(() => {
+    getAppRules().then(setRules).catch(() => {});
+    getTrackedApps().then(setTrackedApps).catch(() => {});
+  }, []);
+
+  const existingAppNames = new Set(rules.map((r) => r.app_name));
+
+  const appNameToAdd = useCustom ? customApp.trim() : selectedApp;
+
+  async function handleAdd() {
+    if (!appNameToAdd) return;
+    setAdding(true);
+    try {
+      const rule = await addAppRule(appNameToAdd, category);
+      setRules((prev) => {
+        const filtered = prev.filter((r) => r.app_name !== rule.app_name);
+        return [...filtered, rule].sort((a, b) => a.app_name.localeCompare(b.app_name));
+      });
+      setSelectedApp("");
+      setCustomApp("");
+    } finally {
+      setAdding(false);
+    }
+  }
+
+  async function handleDelete(id: number) {
+    await deleteAppRule(id);
+    setRules((prev) => prev.filter((r) => r.id !== id));
+  }
+
+  return (
+    <section className="settings-section">
+      <h3 className="settings-section-title">앱 분류 규칙</h3>
+      <p className="settings-desc">
+        Xcode, Slack 등 네이티브 앱을 Focus / Neutral / Distraction으로 분류합니다.
+      </p>
+
+      <div className="settings-rules-list">
+        {rules.length === 0 && (
+          <p className="settings-empty">등록된 앱 규칙이 없습니다.</p>
+        )}
+        {rules.map((rule) => (
+          <div key={rule.id} className="settings-rule-row">
+            <span className="settings-rule-domain">{rule.app_name}</span>
+            <span
+              className={`settings-rule-badge settings-rule-badge--${rule.category.toLowerCase()}`}
+            >
+              {rule.category}
+            </span>
+            <button
+              className="settings-btn-sm settings-btn-sm--danger"
+              onClick={() => handleDelete(rule.id)}
+            >
+              삭제
+            </button>
+          </div>
+        ))}
+      </div>
+
+      <div className="settings-rule-add">
+        <div className="app-rule-source-toggle">
+          <button
+            className={`app-rule-toggle-btn${!useCustom ? " active" : ""}`}
+            onClick={() => setUseCustom(false)}
+          >
+            추적된 앱
+          </button>
+          <button
+            className={`app-rule-toggle-btn${useCustom ? " active" : ""}`}
+            onClick={() => setUseCustom(true)}
+          >
+            직접 입력
+          </button>
+        </div>
+
+        {useCustom ? (
+          <input
+            className="settings-input"
+            placeholder="앱 이름 입력 (예: Xcode)"
+            value={customApp}
+            onChange={(e) => setCustomApp(e.target.value)}
+            onKeyDown={(e) => e.key === "Enter" && handleAdd()}
+          />
+        ) : (
+          <select
+            className="settings-select"
+            value={selectedApp}
+            onChange={(e) => setSelectedApp(e.target.value)}
+          >
+            <option value="">앱 선택...</option>
+            {trackedApps.map((app) => (
+              <option
+                key={app}
+                value={app}
+                disabled={existingAppNames.has(app)}
+              >
+                {app}{existingAppNames.has(app) ? " (규칙 있음)" : ""}
+              </option>
+            ))}
+          </select>
+        )}
+
+        <select
+          className="settings-select"
+          value={category}
+          onChange={(e) => setCategory(e.target.value as Category)}
+        >
+          {CATEGORIES.map((c) => (
+            <option key={c} value={c}>{c}</option>
+          ))}
+        </select>
+
+        <button
+          className="settings-btn-sm"
+          onClick={handleAdd}
+          disabled={adding || !appNameToAdd}
+        >
+          추가
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/src/components/Settings/AutoLaunchSettings.tsx
+++ b/src/components/Settings/AutoLaunchSettings.tsx
@@ -1,0 +1,46 @@
+import { useEffect, useState } from "react";
+import { enable, disable, isEnabled } from "@tauri-apps/plugin-autostart";
+
+export function AutoLaunchSettings() {
+  const [enabled, setEnabled] = useState(false);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    isEnabled().then((v: boolean) => {
+      setEnabled(v);
+      setLoading(false);
+    });
+  }, []);
+
+  const handleToggle = async () => {
+    setLoading(true);
+    try {
+      if (enabled) {
+        await disable();
+        setEnabled(false);
+      } else {
+        await enable();
+        setEnabled(true);
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="settings-section">
+      <h3 className="settings-section__title">시작 프로그램</h3>
+      <label className="settings-toggle">
+        <span className="settings-toggle__label">로그인 시 자동 실행</span>
+        <input
+          type="checkbox"
+          className="settings-toggle__input"
+          checked={enabled}
+          onChange={handleToggle}
+          disabled={loading}
+        />
+        <span className="settings-toggle__slider" />
+      </label>
+    </div>
+  );
+}

--- a/src/components/Settings/TitleRuleSettings.tsx
+++ b/src/components/Settings/TitleRuleSettings.tsx
@@ -1,0 +1,54 @@
+import { useState, useEffect } from "react";
+import type { TitleRule } from "../../types/bindings";
+import { getTitleRules, deleteTitleRule } from "../../services/settings";
+
+const CATEGORY_COLORS: Record<string, string> = {
+  Focus: "focus",
+  Neutral: "neutral",
+  Distraction: "distraction",
+};
+
+export function TitleRuleSettings() {
+  const [rules, setRules] = useState<TitleRule[]>([]);
+
+  useEffect(() => {
+    getTitleRules().then(setRules).catch(() => {});
+  }, []);
+
+  async function handleDelete(id: number) {
+    await deleteTitleRule(id);
+    setRules((prev) => prev.filter((r) => r.id !== id));
+  }
+
+  return (
+    <section className="settings-section">
+      <h3 className="settings-section-title">타이틀 규칙</h3>
+      <p className="settings-desc">
+        Quick Override로 저장된 페이지 제목 키워드 기반 분류 규칙입니다.
+      </p>
+
+      <div className="settings-rules-list">
+        {rules.length === 0 && (
+          <p className="settings-empty">등록된 타이틀 규칙이 없습니다.</p>
+        )}
+        {rules.map((rule) => (
+          <div key={rule.id} className="settings-rule-row">
+            <span className="settings-rule-domain">{rule.domain}</span>
+            <span className="settings-title-rule-keyword">"{rule.keyword}"</span>
+            <span
+              className={`settings-rule-badge settings-rule-badge--${CATEGORY_COLORS[rule.category] ?? "neutral"}`}
+            >
+              {rule.category}
+            </span>
+            <button
+              className="settings-btn-sm settings-btn-sm--danger"
+              onClick={() => handleDelete(rule.id)}
+            >
+              삭제
+            </button>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,4 +1,5 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, Component } from "react";
+import type { ReactNode } from "react";
 import type { Activity, DomainSummary, FocusMetrics, Reference, SessionEvent } from "../types/bindings";
 import { getActivityTimeline, getTopSites, getDailyFocusStats, getSessionEvents } from "../services/activity";
 import { getReferences } from "../services/reference";
@@ -10,6 +11,7 @@ import { DatePicker } from "../components/Dashboard/DatePicker";
 import { WeeklyReport } from "../components/Dashboard/WeeklyReport";
 import { TrendChart } from "../components/Dashboard/TrendChart";
 import { HabitInsights } from "../components/Dashboard/HabitInsights";
+import { ExportButton } from "../components/Dashboard/ExportButton";
 
 function todayDateStr(): string {
   return new Date().toISOString().split("T")[0];
@@ -22,6 +24,29 @@ function shiftDate(dateStr: string, days: number): string {
 }
 
 type Tab = "timeline" | "sites" | "score" | "refs" | "weekly" | "trend";
+
+class TabErrorBoundary extends Component<{ children: ReactNode }, { error: Error | null }> {
+  constructor(props: { children: ReactNode }) {
+    super(props);
+    this.state = { error: null };
+  }
+  static getDerivedStateFromError(error: Error) {
+    return { error };
+  }
+  render() {
+    if (this.state.error) {
+      return (
+        <div className="dash-error">
+          <p>이 탭을 불러오는 중 오류가 발생했습니다.</p>
+          <button className="dash-tab" onClick={() => this.setState({ error: null })}>
+            다시 시도
+          </button>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}
 
 export function Dashboard() {
   const [date, setDate] = useState(todayDateStr);
@@ -73,6 +98,9 @@ export function Dashboard() {
     <div className="dashboard">
       <div className="dash-header">
         <h1 className="dash-title">Dashboard</h1>
+        <div className="dash-header-actions">
+          <ExportButton />
+        </div>
         {isDayTab && (
           <div className="dash-date-nav">
             <button
@@ -108,39 +136,41 @@ export function Dashboard() {
       </div>
 
       <div className="dash-content">
-        {loading && isDayTab ? (
-          <p className="dash-loading">로딩 중...</p>
-        ) : (
-          <>
-            {tab === "timeline" && <ActivityTimeline activities={activities} sessionEvents={sessionEvents} />}
-            {tab === "sites" && <TopSites sites={sites} />}
-            {tab === "score" && <FocusScore metrics={metrics} />}
-            {tab === "weekly" && (
-              <div className="weekly-section">
-                <div className="weekly-section__block">
-                  <h3 className="weekly-section__subtitle">이번 주</h3>
-                  <WeeklyReport weekOffset={0} />
+        <TabErrorBoundary key={tab}>
+          {loading && isDayTab ? (
+            <p className="dash-loading">로딩 중...</p>
+          ) : (
+            <>
+              {tab === "timeline" && <ActivityTimeline activities={activities} sessionEvents={sessionEvents} />}
+              {tab === "sites" && <TopSites sites={sites} />}
+              {tab === "score" && <FocusScore metrics={metrics} />}
+              {tab === "weekly" && (
+                <div className="weekly-section">
+                  <div className="weekly-section__block">
+                    <h3 className="weekly-section__subtitle">이번 주</h3>
+                    <WeeklyReport weekOffset={0} />
+                  </div>
+                  <div className="weekly-section__block">
+                    <h3 className="weekly-section__subtitle">지난 주</h3>
+                    <WeeklyReport weekOffset={-1} />
+                  </div>
                 </div>
-                <div className="weekly-section__block">
-                  <h3 className="weekly-section__subtitle">지난 주</h3>
-                  <WeeklyReport weekOffset={-1} />
+              )}
+              {tab === "trend" && (
+                <div className="trend-section">
+                  <TrendChart />
+                  <HabitInsights />
                 </div>
-              </div>
-            )}
-            {tab === "trend" && (
-              <div className="trend-section">
-                <TrendChart />
-                <HabitInsights />
-              </div>
-            )}
-            {tab === "refs" && (
-              <SavedReferences
-                references={refs}
-                onRefresh={() => getReferences().then(setRefs)}
-              />
-            )}
-          </>
-        )}
+              )}
+              {tab === "refs" && (
+                <SavedReferences
+                  references={refs}
+                  onRefresh={() => getReferences().then(setRefs)}
+                />
+              )}
+            </>
+          )}
+        </TabErrorBoundary>
       </div>
     </div>
   );

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -7,6 +7,9 @@ import { TopSites } from "../components/Dashboard/TopSites";
 import { FocusScore } from "../components/Dashboard/FocusScore";
 import { SavedReferences } from "../components/Dashboard/SavedReferences";
 import { DatePicker } from "../components/Dashboard/DatePicker";
+import { WeeklyReport } from "../components/Dashboard/WeeklyReport";
+import { TrendChart } from "../components/Dashboard/TrendChart";
+import { HabitInsights } from "../components/Dashboard/HabitInsights";
 
 function todayDateStr(): string {
   return new Date().toISOString().split("T")[0];
@@ -18,8 +21,7 @@ function shiftDate(dateStr: string, days: number): string {
   return d.toISOString().split("T")[0];
 }
 
-
-type Tab = "timeline" | "sites" | "score" | "refs";
+type Tab = "timeline" | "sites" | "score" | "refs" | "weekly" | "trend";
 
 export function Dashboard() {
   const [date, setDate] = useState(todayDateStr);
@@ -59,31 +61,38 @@ export function Dashboard() {
     { id: "timeline", label: "타임라인" },
     { id: "sites", label: "Top Sites" },
     { id: "score", label: "Focus Score" },
+    { id: "weekly", label: "주간 리포트" },
+    { id: "trend", label: "트렌드" },
     { id: "refs", label: "References" },
   ];
+
+  // Date nav only relevant for day-based tabs
+  const isDayTab = tab === "timeline" || tab === "sites" || tab === "score";
 
   return (
     <div className="dashboard">
       <div className="dash-header">
         <h1 className="dash-title">Dashboard</h1>
-        <div className="dash-date-nav">
-          <button
-            className="dash-date-btn"
-            onClick={() => setDate((d) => shiftDate(d, -1))}
-            aria-label="이전 날"
-          >
-            ‹
-          </button>
-          <DatePicker value={date} max={todayDateStr()} onChange={setDate} />
-          <button
-            className="dash-date-btn"
-            onClick={() => setDate((d) => shiftDate(d, 1))}
-            disabled={date >= todayDateStr()}
-            aria-label="다음 날"
-          >
-            ›
-          </button>
-        </div>
+        {isDayTab && (
+          <div className="dash-date-nav">
+            <button
+              className="dash-date-btn"
+              onClick={() => setDate((d) => shiftDate(d, -1))}
+              aria-label="이전 날"
+            >
+              ‹
+            </button>
+            <DatePicker value={date} max={todayDateStr()} onChange={setDate} />
+            <button
+              className="dash-date-btn"
+              onClick={() => setDate((d) => shiftDate(d, 1))}
+              disabled={date >= todayDateStr()}
+              aria-label="다음 날"
+            >
+              ›
+            </button>
+          </div>
+        )}
       </div>
 
       <div className="dash-tabs">
@@ -99,13 +108,31 @@ export function Dashboard() {
       </div>
 
       <div className="dash-content">
-        {loading ? (
+        {loading && isDayTab ? (
           <p className="dash-loading">로딩 중...</p>
         ) : (
           <>
             {tab === "timeline" && <ActivityTimeline activities={activities} sessionEvents={sessionEvents} />}
             {tab === "sites" && <TopSites sites={sites} />}
             {tab === "score" && <FocusScore metrics={metrics} />}
+            {tab === "weekly" && (
+              <div className="weekly-section">
+                <div className="weekly-section__block">
+                  <h3 className="weekly-section__subtitle">이번 주</h3>
+                  <WeeklyReport weekOffset={0} />
+                </div>
+                <div className="weekly-section__block">
+                  <h3 className="weekly-section__subtitle">지난 주</h3>
+                  <WeeklyReport weekOffset={-1} />
+                </div>
+              </div>
+            )}
+            {tab === "trend" && (
+              <div className="trend-section">
+                <TrendChart />
+                <HabitInsights />
+              </div>
+            )}
             {tab === "refs" && (
               <SavedReferences
                 references={refs}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,8 +1,120 @@
+import { useState, useEffect, useCallback } from "react";
+import type { Activity, DomainSummary, FocusMetrics, Reference, SessionEvent } from "../types/bindings";
+import { getActivityTimeline, getTopSites, getDailyFocusStats, getSessionEvents } from "../services/activity";
+import { getReferences } from "../services/reference";
+import { ActivityTimeline } from "../components/Dashboard/ActivityTimeline";
+import { TopSites } from "../components/Dashboard/TopSites";
+import { FocusScore } from "../components/Dashboard/FocusScore";
+import { SavedReferences } from "../components/Dashboard/SavedReferences";
+import { DatePicker } from "../components/Dashboard/DatePicker";
+
+function todayDateStr(): string {
+  return new Date().toISOString().split("T")[0];
+}
+
+function shiftDate(dateStr: string, days: number): string {
+  const d = new Date(dateStr);
+  d.setDate(d.getDate() + days);
+  return d.toISOString().split("T")[0];
+}
+
+
+type Tab = "timeline" | "sites" | "score" | "refs";
+
 export function Dashboard() {
+  const [date, setDate] = useState(todayDateStr);
+  const [tab, setTab] = useState<Tab>("timeline");
+  const [activities, setActivities] = useState<Activity[]>([]);
+  const [sessionEvents, setSessionEvents] = useState<SessionEvent[]>([]);
+  const [sites, setSites] = useState<DomainSummary[]>([]);
+  const [metrics, setMetrics] = useState<FocusMetrics | null>(null);
+  const [refs, setRefs] = useState<Reference[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const loadData = useCallback(async (d: string) => {
+    setLoading(true);
+    try {
+      const [acts, events, topSites, focusStats, references] = await Promise.all([
+        getActivityTimeline(d),
+        getSessionEvents(d),
+        getTopSites(d, 20),
+        getDailyFocusStats(d),
+        getReferences(),
+      ]);
+      setActivities(acts);
+      setSessionEvents(events);
+      setSites(topSites);
+      setMetrics(focusStats);
+      setRefs(references);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadData(date);
+  }, [date, loadData]);
+
+  const TABS: { id: Tab; label: string }[] = [
+    { id: "timeline", label: "타임라인" },
+    { id: "sites", label: "Top Sites" },
+    { id: "score", label: "Focus Score" },
+    { id: "refs", label: "References" },
+  ];
+
   return (
-    <div style={{ padding: 24 }}>
-      <h1>Dashboard</h1>
-      <p>준비 중입니다.</p>
+    <div className="dashboard">
+      <div className="dash-header">
+        <h1 className="dash-title">Dashboard</h1>
+        <div className="dash-date-nav">
+          <button
+            className="dash-date-btn"
+            onClick={() => setDate((d) => shiftDate(d, -1))}
+            aria-label="이전 날"
+          >
+            ‹
+          </button>
+          <DatePicker value={date} max={todayDateStr()} onChange={setDate} />
+          <button
+            className="dash-date-btn"
+            onClick={() => setDate((d) => shiftDate(d, 1))}
+            disabled={date >= todayDateStr()}
+            aria-label="다음 날"
+          >
+            ›
+          </button>
+        </div>
+      </div>
+
+      <div className="dash-tabs">
+        {TABS.map((t) => (
+          <button
+            key={t.id}
+            className={`dash-tab${tab === t.id ? " dash-tab--active" : ""}`}
+            onClick={() => setTab(t.id)}
+          >
+            {t.label}
+          </button>
+        ))}
+      </div>
+
+      <div className="dash-content">
+        {loading ? (
+          <p className="dash-loading">로딩 중...</p>
+        ) : (
+          <>
+            {tab === "timeline" && <ActivityTimeline activities={activities} sessionEvents={sessionEvents} />}
+            {tab === "sites" && <TopSites sites={sites} />}
+            {tab === "score" && <FocusScore metrics={metrics} />}
+            {tab === "refs" && (
+              <SavedReferences
+                references={refs}
+                onRefresh={() => getReferences().then(setRefs)}
+              />
+            )}
+          </>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -82,6 +82,22 @@ export function Dashboard() {
     loadData(date);
   }, [date, loadData]);
 
+  // 오늘 날짜를 보는 중이면 30초마다 자동 갱신
+  useEffect(() => {
+    if (date !== todayDateStr()) return;
+    const id = setInterval(() => loadData(date), 30_000);
+    return () => clearInterval(id);
+  }, [date, loadData]);
+
+  // 창이 포커스를 받거나 탭이 visible 되면 즉시 갱신
+  useEffect(() => {
+    const onVisible = () => {
+      if (document.visibilityState === "visible") loadData(date);
+    };
+    document.addEventListener("visibilitychange", onVisible);
+    return () => document.removeEventListener("visibilitychange", onVisible);
+  }, [date, loadData]);
+
   const TABS: { id: Tab; label: string }[] = [
     { id: "timeline", label: "타임라인" },
     { id: "sites", label: "Top Sites" },
@@ -96,43 +112,45 @@ export function Dashboard() {
 
   return (
     <div className="dashboard">
-      <div className="dash-header">
-        <h1 className="dash-title">Dashboard</h1>
-        <div className="dash-header-actions">
-          <ExportButton />
-        </div>
-        {isDayTab && (
-          <div className="dash-date-nav">
-            <button
-              className="dash-date-btn"
-              onClick={() => setDate((d) => shiftDate(d, -1))}
-              aria-label="이전 날"
-            >
-              ‹
-            </button>
-            <DatePicker value={date} max={todayDateStr()} onChange={setDate} />
-            <button
-              className="dash-date-btn"
-              onClick={() => setDate((d) => shiftDate(d, 1))}
-              disabled={date >= todayDateStr()}
-              aria-label="다음 날"
-            >
-              ›
-            </button>
+      <div className="dash-sticky-top">
+        <div className="dash-header">
+          <h1 className="dash-title">Dashboard</h1>
+          <div className="dash-header-actions">
+            <ExportButton />
           </div>
-        )}
-      </div>
+          {isDayTab && (
+            <div className="dash-date-nav">
+              <button
+                className="dash-date-btn"
+                onClick={() => setDate((d) => shiftDate(d, -1))}
+                aria-label="이전 날"
+              >
+                ‹
+              </button>
+              <DatePicker value={date} max={todayDateStr()} onChange={setDate} />
+              <button
+                className="dash-date-btn"
+                onClick={() => setDate((d) => shiftDate(d, 1))}
+                disabled={date >= todayDateStr()}
+                aria-label="다음 날"
+              >
+                ›
+              </button>
+            </div>
+          )}
+        </div>
 
-      <div className="dash-tabs">
-        {TABS.map((t) => (
-          <button
-            key={t.id}
-            className={`dash-tab${tab === t.id ? " dash-tab--active" : ""}`}
-            onClick={() => setTab(t.id)}
-          >
-            {t.label}
-          </button>
-        ))}
+        <div className="dash-tabs">
+          {TABS.map((t) => (
+            <button
+              key={t.id}
+              className={`dash-tab${tab === t.id ? " dash-tab--active" : ""}`}
+              onClick={() => setTab(t.id)}
+            >
+              {t.label}
+            </button>
+          ))}
+        </div>
       </div>
 
       <div className="dash-content">

--- a/src/pages/Dropdown.tsx
+++ b/src/pages/Dropdown.tsx
@@ -11,6 +11,7 @@ import {
   getTopApps,
   getCurrentApp,
   getCurrentUrl,
+  checkAccessibilityPermission,
 } from "../services/session";
 import { DonutChart } from "../components/Dropdown/DonutChart";
 import { openSaveReferenceWindow, openSettingsWindow } from "../services/settings";
@@ -38,12 +39,14 @@ export function Dropdown() {
   const [currentApp, setCurrentApp] = useState<string | null>(null);
   const [elapsed, setElapsed] = useState(0);
   const [currentUrl, setCurrentUrl] = useState<string | null>(null);
+  const [accessibilityGranted, setAccessibilityGranted] = useState(true);
 
-  // Recovery check on mount
+  // Recovery + 권한 체크 on mount
   useEffect(() => {
     if (recoveryChecked) return;
     setRecoveryChecked(true);
     getIncompleteSession().then((s) => { if (s) setIncompleteSession(s); });
+    checkAccessibilityPermission().then((granted) => setAccessibilityGranted(granted));
   }, [recoveryChecked]);
 
   // Poll stats every 5s when session active
@@ -112,6 +115,14 @@ export function Dropdown() {
 
   return (
     <div className="dropdown">
+      {/* Accessibility 권한 없을 때 안내 배너 */}
+      {!accessibilityGranted && (
+        <div className="dd-permission-banner">
+          <span>⚠️</span>
+          <span>활동 추적을 위해 손쉬운 사용 권한이 필요합니다.</span>
+        </div>
+      )}
+
       {/* Header: timer + focus % */}
       <div className="dd-header">
         <div className="dd-timer">{session ? formatTimer(elapsed) : "--:--"}</div>

--- a/src/pages/Dropdown.tsx
+++ b/src/pages/Dropdown.tsx
@@ -13,7 +13,7 @@ import {
   getCurrentUrl,
 } from "../services/session";
 import { DonutChart } from "../components/Dropdown/DonutChart";
-import { SaveReference } from "../components/Dropdown/SaveReference";
+import { openSaveReferenceWindow, openSettingsWindow } from "../services/settings";
 
 function formatTimer(totalSecs: number): string {
   const h = Math.floor(totalSecs / 3600);
@@ -162,11 +162,20 @@ export function Dropdown() {
 
       {/* Reference 저장 (세션 진행 중일 때만) */}
       {session && (
-        <SaveReference currentUrl={currentUrl} />
+        <button
+          className={`dashboard-btn${currentUrl ? " dashboard-btn--active" : ""}`}
+          onClick={openSaveReferenceWindow}
+          disabled={!currentUrl}
+        >
+          Reference 저장
+        </button>
       )}
 
       {/* Footer */}
-      <button onClick={openDashboard} className="dashboard-btn">Dashboard 열기</button>
+      <div className="dd-footer">
+        <button onClick={openDashboard} className="dashboard-btn">Dashboard 열기</button>
+        <button onClick={openSettingsWindow} className="dashboard-btn">설정</button>
+      </div>
     </div>
   );
 }

--- a/src/pages/Dropdown.tsx
+++ b/src/pages/Dropdown.tsx
@@ -11,9 +11,11 @@ import {
   getTopApps,
   getCurrentApp,
   getCurrentUrl,
+  getCurrentTitle,
   checkAccessibilityPermission,
 } from "../services/session";
 import { DonutChart } from "../components/Dropdown/DonutChart";
+import { QuickOverride } from "../components/Dropdown/QuickOverride";
 import { openSaveReferenceWindow, openSettingsWindow } from "../services/settings";
 
 function formatTimer(totalSecs: number): string {
@@ -39,7 +41,9 @@ export function Dropdown() {
   const [currentApp, setCurrentApp] = useState<string | null>(null);
   const [elapsed, setElapsed] = useState(0);
   const [currentUrl, setCurrentUrl] = useState<string | null>(null);
+  const [currentTitle, setCurrentTitle] = useState<string | null>(null);
   const [accessibilityGranted, setAccessibilityGranted] = useState(true);
+  const [showQuickOverride, setShowQuickOverride] = useState(false);
 
   // Recovery + 권한 체크 on mount
   useEffect(() => {
@@ -51,16 +55,18 @@ export function Dropdown() {
 
   // Poll stats every 5s when session active
   const refreshStats = useCallback(async (sid: string) => {
-    const [s, apps, app, url] = await Promise.all([
+    const [s, apps, app, url, title] = await Promise.all([
       getFocusStats(sid),
       getTopApps(sid),
       getCurrentApp(),
       getCurrentUrl(),
+      getCurrentTitle(),
     ]);
     setStats(s);
     setTopApps(apps);
     setCurrentApp(app);
     setCurrentUrl(url);
+    setCurrentTitle(title);
     setElapsed(s.total_secs);
   }, []);
 
@@ -153,8 +159,27 @@ export function Dropdown() {
           <div className="dd-current-app">
             <div className="dd-current-app__label">현재 앱</div>
             <div className="dd-current-app__name">{currentApp ?? "—"}</div>
+            {currentUrl && (
+              <button
+                className="dd-current-app__override-btn"
+                onClick={() => setShowQuickOverride((v) => !v)}
+                title="분류 변경"
+              >
+                분류 변경
+              </button>
+            )}
           </div>
         </div>
+      )}
+
+      {/* Quick override panel */}
+      {session && showQuickOverride && currentUrl && (
+        <QuickOverride
+          domain={currentUrl ? new URL(currentUrl).hostname.replace(/^www\./, "") : null}
+          title={currentTitle}
+          currentCategory={topApps[0]?.classification ?? "Neutral"}
+          onClose={() => setShowQuickOverride(false)}
+        />
       )}
 
       {/* Recent apps list */}

--- a/src/pages/Dropdown.tsx
+++ b/src/pages/Dropdown.tsx
@@ -15,6 +15,7 @@ import {
   checkAccessibilityPermission,
 } from "../services/session";
 import { DonutChart } from "../components/Dropdown/DonutChart";
+import { GoalProgress } from "../components/Dropdown/GoalProgress";
 import { QuickOverride } from "../components/Dropdown/QuickOverride";
 import { openSaveReferenceWindow, openSettingsWindow } from "../services/settings";
 
@@ -181,6 +182,9 @@ export function Dropdown() {
           onClose={() => setShowQuickOverride(false)}
         />
       )}
+
+      {/* 오늘 집중 목표 */}
+      {session && <GoalProgress />}
 
       {/* Recent apps list */}
       {session && topApps.length > 0 && (

--- a/src/pages/Dropdown.tsx
+++ b/src/pages/Dropdown.tsx
@@ -74,7 +74,7 @@ export function Dropdown() {
   useEffect(() => {
     if (!session) { setStats(null); setTopApps([]); setElapsed(0); return; }
     refreshStats(session.id);
-    const interval = setInterval(() => refreshStats(session.id), 5000);
+    const interval = setInterval(() => refreshStats(session.id), 3000);
     return () => clearInterval(interval);
   }, [session, refreshStats]);
 

--- a/src/pages/Onboarding.tsx
+++ b/src/pages/Onboarding.tsx
@@ -1,0 +1,143 @@
+import { useState } from "react";
+import { getCurrentWindow } from "@tauri-apps/api/window";
+import { applyProfessionRules, completeOnboarding, type Profession } from "../services/onboarding";
+
+type Step = "welcome" | "profession" | "done";
+
+const PROFESSIONS: { value: Profession; label: string; description: string }[] = [
+  { value: "developer", label: "개발자", description: "코딩, 터미널, GitHub 등" },
+  { value: "designer", label: "디자이너", description: "Figma, Dribbble, Behance 등" },
+  { value: "marketer", label: "마케터", description: "Analytics, Ads, HubSpot 등" },
+  { value: "student", label: "학생", description: "Coursera, Khan Academy, Wikipedia 등" },
+  { value: "other", label: "기타 / 직접 설정", description: "기본 규칙만 적용됩니다" },
+];
+
+export function Onboarding() {
+  const [step, setStep] = useState<Step>("welcome");
+  const [selected, setSelected] = useState<Profession | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const handleProfessionNext = async () => {
+    if (!selected) return;
+    setLoading(true);
+    try {
+      await applyProfessionRules(selected);
+      setStep("done");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleSkip = async () => {
+    setLoading(true);
+    try {
+      await completeOnboarding();
+      await getCurrentWindow().close();
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleFinish = async () => {
+    setLoading(true);
+    try {
+      await completeOnboarding();
+      await getCurrentWindow().close();
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="onboarding">
+      {step === "welcome" && (
+        <div className="onboarding__step">
+          <div className="onboarding__icon">🎯</div>
+          <h1 className="onboarding__title">focaro에 오신 것을 환영합니다</h1>
+          <p className="onboarding__desc">
+            focaro는 컴퓨터 활동을 추적하여 집중 시간을 분석하는 메뉴바 앱입니다.
+          </p>
+          <ul className="onboarding__features">
+            <li>✅ 앱 및 브라우저 활동 자동 추적</li>
+            <li>✅ Focus / Neutral / Distraction 분류</li>
+            <li>✅ 세션 단위 집중도 분석</li>
+            <li>✅ Reference URL 저장</li>
+          </ul>
+          <div className="onboarding__actions">
+            <button
+              className="onboarding__btn onboarding__btn--primary"
+              onClick={() => setStep("profession")}
+            >
+              시작하기
+            </button>
+            <button
+              className="onboarding__btn onboarding__btn--ghost"
+              onClick={handleSkip}
+              disabled={loading}
+            >
+              건너뛰기
+            </button>
+          </div>
+        </div>
+      )}
+
+      {step === "profession" && (
+        <div className="onboarding__step">
+          <h2 className="onboarding__title">직업을 선택해주세요</h2>
+          <p className="onboarding__desc">
+            선택에 맞는 앱/사이트가 자동으로 Focus로 분류됩니다.
+          </p>
+          <div className="onboarding__professions">
+            {PROFESSIONS.map((p) => (
+              <button
+                key={p.value}
+                className={`onboarding__profession${selected === p.value ? " onboarding__profession--selected" : ""}`}
+                onClick={() => setSelected(p.value)}
+              >
+                <span className="onboarding__profession-label">{p.label}</span>
+                <span className="onboarding__profession-desc">{p.description}</span>
+              </button>
+            ))}
+          </div>
+          <div className="onboarding__actions">
+            <button
+              className="onboarding__btn onboarding__btn--primary"
+              onClick={handleProfessionNext}
+              disabled={!selected || loading}
+            >
+              {loading ? "적용 중..." : "다음"}
+            </button>
+            <button
+              className="onboarding__btn onboarding__btn--ghost"
+              onClick={handleSkip}
+              disabled={loading}
+            >
+              건너뛰기
+            </button>
+          </div>
+        </div>
+      )}
+
+      {step === "done" && (
+        <div className="onboarding__step">
+          <div className="onboarding__icon">🟢</div>
+          <h2 className="onboarding__title">설정 완료!</h2>
+          <p className="onboarding__desc">
+            메뉴바 아이콘을 클릭하여 세션을 시작할 수 있습니다.
+            <br />
+            설정 &gt; 분류 규칙에서 언제든지 수정할 수 있습니다.
+          </p>
+          <div className="onboarding__actions">
+            <button
+              className="onboarding__btn onboarding__btn--primary"
+              onClick={handleFinish}
+              disabled={loading}
+            >
+              {loading ? "저장 중..." : "시작하기"}
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/pages/SaveReferencePage.tsx
+++ b/src/pages/SaveReferencePage.tsx
@@ -1,0 +1,92 @@
+import { useState, useEffect } from "react";
+import { getCurrentWindow } from "@tauri-apps/api/window";
+import { saveReference } from "../services/reference";
+import { getCurrentUrl, getCurrentTitle } from "../services/session";
+
+export function SaveReferencePage() {
+  const [url, setUrl] = useState<string>("");
+  const [title, setTitle] = useState("");
+  const [tags, setTags] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const [currentUrl, currentTitle] = await Promise.all([
+          getCurrentUrl(),
+          getCurrentTitle(),
+        ]);
+        if (currentUrl) setUrl(currentUrl);
+        if (currentTitle) setTitle(currentTitle);
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, []);
+
+  const handleSave = async () => {
+    if (!title.trim() || !url) return;
+    setSaving(true);
+    try {
+      const tagList = tags.trim()
+        ? tags.split(",").map((t) => t.trim()).filter(Boolean)
+        : [];
+      await saveReference({
+        url,
+        title: title.trim(),
+        tags: tagList.length > 0 ? tagList : null,
+      });
+      getCurrentWindow().close();
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleCancel = () => {
+    getCurrentWindow().close();
+  };
+
+  return (
+    <div className="save-ref-page">
+      <h2 className="save-ref-page-title">Reference 저장</h2>
+
+      {url && (
+        <p className="save-ref-page-url">{url}</p>
+      )}
+
+      <input
+        className="save-ref-page-input"
+        placeholder="제목 입력"
+        value={loading ? "" : title}
+        onChange={(e) => setTitle(e.target.value)}
+        autoFocus={!loading}
+        disabled={loading}
+      />
+
+      <input
+        className="save-ref-page-input"
+        placeholder="태그 (쉼표로 구분, 선택)"
+        value={tags}
+        onChange={(e) => setTags(e.target.value)}
+        disabled={loading}
+      />
+
+      <div className="save-ref-page-actions">
+        <button
+          className="save-ref-page-btn save-ref-page-btn--primary"
+          onClick={handleSave}
+          disabled={saving || !title.trim() || loading}
+        >
+          {saving ? "저장 중..." : "저장"}
+        </button>
+        <button
+          className="save-ref-page-btn"
+          onClick={handleCancel}
+        >
+          취소
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -7,6 +7,7 @@ import {
   addClassificationRule,
   deleteClassificationRule,
 } from "../services/settings";
+import { AutoLaunchSettings } from "../components/Settings/AutoLaunchSettings";
 
 const RETENTION_OPTIONS = [
   { label: "7일", value: 7 },
@@ -89,6 +90,9 @@ export function Settings() {
   return (
     <div className="settings-page">
       <h2 className="settings-title">focaro 설정</h2>
+
+      {/* 자동 실행 설정 */}
+      <AutoLaunchSettings />
 
       {/* 단축키 설정 */}
       <section className="settings-section">

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -9,6 +9,7 @@ import {
 } from "../services/settings";
 import { AutoLaunchSettings } from "../components/Settings/AutoLaunchSettings";
 import { AppRuleSettings } from "../components/Settings/AppRuleSettings";
+import { TitleRuleSettings } from "../components/Settings/TitleRuleSettings";
 
 const RETENTION_OPTIONS = [
   { label: "7일", value: 7 },
@@ -196,6 +197,8 @@ export function Settings() {
       </section>
 
       <AppRuleSettings />
+
+      <TitleRuleSettings />
 
       {/* 저장 버튼 */}
       <div className="settings-footer">

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -8,6 +8,7 @@ import {
   deleteClassificationRule,
 } from "../services/settings";
 import { AutoLaunchSettings } from "../components/Settings/AutoLaunchSettings";
+import { AppRuleSettings } from "../components/Settings/AppRuleSettings";
 
 const RETENTION_OPTIONS = [
   { label: "7일", value: 7 },
@@ -193,6 +194,8 @@ export function Settings() {
           </button>
         </div>
       </section>
+
+      <AppRuleSettings />
 
       {/* 저장 버튼 */}
       <div className="settings-footer">

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,0 +1,205 @@
+import { useState, useEffect, useCallback } from "react";
+import type { AppSettings, ClassificationRule } from "../types/bindings";
+import {
+  getSettings,
+  updateSettings,
+  getClassificationRules,
+  addClassificationRule,
+  deleteClassificationRule,
+} from "../services/settings";
+
+const RETENTION_OPTIONS = [
+  { label: "7일", value: 7 },
+  { label: "30일", value: 30 },
+  { label: "90일", value: 90 },
+  { label: "무제한", value: 0 },
+];
+
+const CATEGORY_OPTIONS = ["Focus", "Neutral", "Distraction"] as const;
+
+export function Settings() {
+  const [settings, setSettings] = useState<AppSettings | null>(null);
+  const [rules, setRules] = useState<ClassificationRule[]>([]);
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [newDomain, setNewDomain] = useState("");
+  const [newCategory, setNewCategory] = useState<string>("Focus");
+  const [addingRule, setAddingRule] = useState(false);
+  const [shortcutEditing, setShortcutEditing] = useState(false);
+  const [shortcutInput, setShortcutInput] = useState("");
+
+  const loadData = useCallback(async () => {
+    const [s, r] = await Promise.all([getSettings(), getClassificationRules()]);
+    setSettings(s);
+    setRules(r);
+  }, []);
+
+  useEffect(() => {
+    loadData();
+  }, [loadData]);
+
+  const handleSave = async () => {
+    if (!settings) return;
+    setSaving(true);
+    try {
+      await updateSettings(settings);
+      setSaved(true);
+      setTimeout(() => setSaved(false), 2000);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleShortcutCapture = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    e.preventDefault();
+    const parts: string[] = [];
+    if (e.metaKey) parts.push("CmdOrCtrl");
+    if (e.ctrlKey && !e.metaKey) parts.push("CmdOrCtrl");
+    if (e.altKey) parts.push("Alt");
+    if (e.shiftKey) parts.push("Shift");
+    const key = e.key.toUpperCase();
+    if (key.length === 1 || ["F1","F2","F3","F4","F5","F6","F7","F8","F9","F10","F11","F12"].includes(key)) {
+      parts.push(key);
+      const combo = parts.join("+");
+      setShortcutInput(combo);
+      setSettings((s) => s ? { ...s, shortcut_save_ref: combo } : s);
+      setShortcutEditing(false);
+    }
+  };
+
+  const handleAddRule = async () => {
+    if (!newDomain.trim()) return;
+    setAddingRule(true);
+    try {
+      const rule = await addClassificationRule(newDomain.trim(), newCategory);
+      setRules((r) => [...r, rule]);
+      setNewDomain("");
+    } finally {
+      setAddingRule(false);
+    }
+  };
+
+  const handleDeleteRule = async (id: number) => {
+    await deleteClassificationRule(id);
+    setRules((r) => r.filter((rule) => rule.id !== id));
+  };
+
+  if (!settings) return <div className="settings-loading">로딩 중...</div>;
+
+  return (
+    <div className="settings-page">
+      <h2 className="settings-title">focaro 설정</h2>
+
+      {/* 단축키 설정 */}
+      <section className="settings-section">
+        <h3 className="settings-section-title">전역 단축키</h3>
+        <p className="settings-desc">Reference 저장 팝업을 여는 단축키입니다.</p>
+        <div className="settings-shortcut-row">
+          {shortcutEditing ? (
+            <input
+              className="settings-shortcut-input"
+              placeholder="키를 누르세요..."
+              value={shortcutInput}
+              onKeyDown={handleShortcutCapture}
+              onChange={() => {}}
+              autoFocus
+            />
+          ) : (
+            <span className="settings-shortcut-badge">
+              {settings.shortcut_save_ref}
+            </span>
+          )}
+          <button
+            className="settings-btn-sm"
+            onClick={() => {
+              setShortcutInput(settings.shortcut_save_ref);
+              setShortcutEditing((v) => !v);
+            }}
+          >
+            {shortcutEditing ? "취소" : "변경"}
+          </button>
+        </div>
+      </section>
+
+      {/* 보관 기간 */}
+      <section className="settings-section">
+        <h3 className="settings-section-title">보관 기간</h3>
+        <p className="settings-desc">이보다 오래된 활동 데이터는 자동으로 삭제됩니다.</p>
+        <div className="settings-radio-group">
+          {RETENTION_OPTIONS.map(({ label, value }) => (
+            <label key={value} className="settings-radio-label" aria-label={label}>
+              <input
+                type="radio"
+                name="retention"
+                value={value}
+                checked={settings.retention_days === value}
+                onChange={() => setSettings((s) => s ? { ...s, retention_days: value } : s)}
+              />
+              {label}
+            </label>
+          ))}
+        </div>
+      </section>
+
+      {/* 분류 규칙 */}
+      <section className="settings-section">
+        <h3 className="settings-section-title">분류 규칙</h3>
+        <p className="settings-desc">도메인에 따라 Focus / Neutral / Distraction을 지정합니다.</p>
+
+        <div className="settings-rules-list">
+          {rules.map((rule) => (
+            <div key={rule.id} className="settings-rule-row">
+              <span className="settings-rule-domain">{rule.domain}</span>
+              <span className={`settings-rule-badge settings-rule-badge--${rule.category.toLowerCase()}`}>
+                {rule.category}
+              </span>
+              <button
+                className="settings-btn-sm settings-btn-sm--danger"
+                onClick={() => handleDeleteRule(rule.id)}
+              >
+                삭제
+              </button>
+            </div>
+          ))}
+        </div>
+
+        <div className="settings-rule-add">
+          <input
+            className="settings-input"
+            placeholder="도메인 입력 (예: example.com)"
+            value={newDomain}
+            onChange={(e) => setNewDomain(e.target.value)}
+            onKeyDown={(e) => e.key === "Enter" && handleAddRule()}
+          />
+          <select
+            className="settings-select"
+            value={newCategory}
+            onChange={(e) => setNewCategory(e.target.value)}
+          >
+            {CATEGORY_OPTIONS.map((c) => (
+              <option key={c} value={c}>{c}</option>
+            ))}
+          </select>
+          <button
+            className="settings-btn-sm"
+            onClick={handleAddRule}
+            disabled={addingRule || !newDomain.trim()}
+          >
+            추가
+          </button>
+        </div>
+      </section>
+
+      {/* 저장 버튼 */}
+      <div className="settings-footer">
+        <button
+          className="settings-save-btn"
+          onClick={handleSave}
+          disabled={saving}
+        >
+          {saved ? "저장됨 ✓" : saving ? "저장 중..." : "저장"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/services/activity.ts
+++ b/src/services/activity.ts
@@ -16,3 +16,7 @@ export async function getDailyFocusStats(date: string): Promise<FocusMetrics> {
 export async function getSessionEvents(date: string): Promise<SessionEvent[]> {
   return invoke<SessionEvent[]>("get_session_events", { date });
 }
+
+export async function getTrackedApps(): Promise<string[]> {
+  return invoke<string[]>("get_tracked_apps");
+}

--- a/src/services/activity.ts
+++ b/src/services/activity.ts
@@ -1,0 +1,18 @@
+import { invoke } from "@tauri-apps/api/core";
+import type { Activity, DomainSummary, FocusMetrics, SessionEvent } from "../types/bindings";
+
+export async function getActivityTimeline(date: string): Promise<Activity[]> {
+  return invoke<Activity[]>("get_activity_timeline", { date });
+}
+
+export async function getTopSites(date: string, limit: number = 10): Promise<DomainSummary[]> {
+  return invoke<DomainSummary[]>("get_top_sites", { date, limit });
+}
+
+export async function getDailyFocusStats(date: string): Promise<FocusMetrics> {
+  return invoke<FocusMetrics>("get_daily_focus_stats", { date });
+}
+
+export async function getSessionEvents(date: string): Promise<SessionEvent[]> {
+  return invoke<SessionEvent[]>("get_session_events", { date });
+}

--- a/src/services/export.ts
+++ b/src/services/export.ts
@@ -1,0 +1,11 @@
+import { invoke } from "@tauri-apps/api/core";
+
+export type ExportFormat = "csv" | "json";
+
+export async function exportData(
+  startDate: string,
+  endDate: string,
+  format: ExportFormat,
+): Promise<string> {
+  return invoke<string>("export_data", { startDate, endDate, format });
+}

--- a/src/services/goal.ts
+++ b/src/services/goal.ts
@@ -1,0 +1,25 @@
+import { invoke } from "@tauri-apps/api/core";
+
+export interface DailyGoal {
+  date: string;
+  target_secs: number;
+}
+
+export interface GoalProgress {
+  date: string;
+  target_secs: number;
+  actual_focus_secs: number;
+  progress_pct: number;
+}
+
+export async function getDailyGoal(date?: string): Promise<DailyGoal> {
+  return invoke<DailyGoal>("get_daily_goal", { date });
+}
+
+export async function setDailyGoal(target_secs: number, date?: string): Promise<DailyGoal> {
+  return invoke<DailyGoal>("set_daily_goal", { targetSecs: target_secs, date });
+}
+
+export async function getGoalProgress(date?: string): Promise<GoalProgress> {
+  return invoke<GoalProgress>("get_goal_progress", { date });
+}

--- a/src/services/onboarding.ts
+++ b/src/services/onboarding.ts
@@ -1,0 +1,45 @@
+import { invoke } from "@tauri-apps/api/core";
+
+export type Profession = "developer" | "designer" | "marketer" | "student" | "other";
+
+export interface TitleRule {
+  id: number;
+  domain: string;
+  keyword: string;
+  category: string;
+}
+
+export async function getOnboardingStatus(): Promise<boolean> {
+  return invoke<boolean>("get_onboarding_status");
+}
+
+export async function completeOnboarding(): Promise<void> {
+  return invoke<void>("complete_onboarding");
+}
+
+export async function applyProfessionRules(profession: Profession): Promise<void> {
+  return invoke<void>("apply_profession_rules", { profession });
+}
+
+export async function getTitleRules(): Promise<TitleRule[]> {
+  return invoke<TitleRule[]>("get_title_rules");
+}
+
+export async function addTitleRule(
+  domain: string,
+  keyword: string,
+  category: string
+): Promise<TitleRule> {
+  return invoke<TitleRule>("add_title_rule", { domain, keyword, category });
+}
+
+export async function deleteTitleRule(id: number): Promise<void> {
+  return invoke<void>("delete_title_rule", { id });
+}
+
+export async function overrideActivityClassification(
+  activityId: string,
+  category: string
+): Promise<void> {
+  return invoke<void>("override_activity_classification", { activityId, category });
+}

--- a/src/services/reference.ts
+++ b/src/services/reference.ts
@@ -1,5 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
-import type { Reference } from "../types/bindings";
+import type { Reference, UpdateReferenceInput } from "../types/bindings";
 
 export interface SaveReferenceInput {
   url: string;
@@ -13,4 +13,16 @@ export async function saveReference(input: SaveReferenceInput): Promise<Referenc
 
 export async function getReferences(sessionId?: string): Promise<Reference[]> {
   return invoke<Reference[]>("get_references", { sessionId: sessionId ?? null });
+}
+
+export async function deleteReference(id: string): Promise<void> {
+  return invoke<void>("delete_reference", { id });
+}
+
+export async function updateReference(input: UpdateReferenceInput): Promise<Reference> {
+  return invoke<Reference>("update_reference", { input });
+}
+
+export async function getCurrentTitle(): Promise<string | null> {
+  return invoke<string | null>("get_current_title");
 }

--- a/src/services/session.ts
+++ b/src/services/session.ts
@@ -44,3 +44,7 @@ export async function getCurrentApp(): Promise<string | null> {
 export async function getCurrentUrl(): Promise<string | null> {
   return invoke<string | null>("get_current_url");
 }
+
+export async function getCurrentTitle(): Promise<string | null> {
+  return invoke<string | null>("get_current_title");
+}

--- a/src/services/session.ts
+++ b/src/services/session.ts
@@ -48,3 +48,7 @@ export async function getCurrentUrl(): Promise<string | null> {
 export async function getCurrentTitle(): Promise<string | null> {
   return invoke<string | null>("get_current_title");
 }
+
+export async function checkAccessibilityPermission(): Promise<boolean> {
+  return invoke<boolean>("check_accessibility_permission");
+}

--- a/src/services/settings.ts
+++ b/src/services/settings.ts
@@ -1,7 +1,7 @@
 import { invoke } from "@tauri-apps/api/core";
-import type { AppSettings, ClassificationRule, AppRule } from "../types/bindings";
+import type { AppSettings, ClassificationRule, AppRule, TitleRule } from "../types/bindings";
 
-export type { AppSettings, ClassificationRule, AppRule };
+export type { AppSettings, ClassificationRule, AppRule, TitleRule };
 
 export async function getSettings(): Promise<AppSettings> {
   return invoke<AppSettings>("get_settings");
@@ -44,4 +44,12 @@ export async function addAppRule(appName: string, category: string): Promise<App
 
 export async function deleteAppRule(id: number): Promise<void> {
   return invoke("delete_app_rule", { id });
+}
+
+export async function getTitleRules(): Promise<TitleRule[]> {
+  return invoke<TitleRule[]>("get_title_rules");
+}
+
+export async function deleteTitleRule(id: number): Promise<void> {
+  return invoke("delete_title_rule", { id });
 }

--- a/src/services/settings.ts
+++ b/src/services/settings.ts
@@ -1,7 +1,7 @@
 import { invoke } from "@tauri-apps/api/core";
-import type { AppSettings, ClassificationRule } from "../types/bindings";
+import type { AppSettings, ClassificationRule, AppRule } from "../types/bindings";
 
-export type { AppSettings, ClassificationRule };
+export type { AppSettings, ClassificationRule, AppRule };
 
 export async function getSettings(): Promise<AppSettings> {
   return invoke<AppSettings>("get_settings");
@@ -32,4 +32,16 @@ export async function openSettingsWindow(): Promise<void> {
 
 export async function openSaveReferenceWindow(): Promise<void> {
   return invoke("open_save_reference_window");
+}
+
+export async function getAppRules(): Promise<AppRule[]> {
+  return invoke<AppRule[]>("get_app_rules");
+}
+
+export async function addAppRule(appName: string, category: string): Promise<AppRule> {
+  return invoke<AppRule>("add_app_rule", { appName, category });
+}
+
+export async function deleteAppRule(id: number): Promise<void> {
+  return invoke("delete_app_rule", { id });
 }

--- a/src/services/settings.ts
+++ b/src/services/settings.ts
@@ -1,0 +1,43 @@
+import { invoke } from "@tauri-apps/api/core";
+
+export interface AppSettings {
+  retention_days: number;
+  shortcut_save_ref: string;
+}
+
+export interface ClassificationRule {
+  id: number;
+  domain: string;
+  category: string;
+}
+
+export async function getSettings(): Promise<AppSettings> {
+  return invoke<AppSettings>("get_settings");
+}
+
+export async function updateSettings(settings: AppSettings): Promise<void> {
+  return invoke("update_settings", { settings });
+}
+
+export async function getClassificationRules(): Promise<ClassificationRule[]> {
+  return invoke<ClassificationRule[]>("get_classification_rules");
+}
+
+export async function addClassificationRule(
+  domain: string,
+  category: string
+): Promise<ClassificationRule> {
+  return invoke<ClassificationRule>("add_classification_rule", { domain, category });
+}
+
+export async function deleteClassificationRule(id: number): Promise<void> {
+  return invoke("delete_classification_rule", { id });
+}
+
+export async function openSettingsWindow(): Promise<void> {
+  return invoke("open_settings_window");
+}
+
+export async function openSaveReferenceWindow(): Promise<void> {
+  return invoke("open_save_reference_window");
+}

--- a/src/services/settings.ts
+++ b/src/services/settings.ts
@@ -1,15 +1,7 @@
 import { invoke } from "@tauri-apps/api/core";
+import type { AppSettings, ClassificationRule } from "../types/bindings";
 
-export interface AppSettings {
-  retention_days: number;
-  shortcut_save_ref: string;
-}
-
-export interface ClassificationRule {
-  id: number;
-  domain: string;
-  category: string;
-}
+export type { AppSettings, ClassificationRule };
 
 export async function getSettings(): Promise<AppSettings> {
   return invoke<AppSettings>("get_settings");

--- a/src/services/stats.ts
+++ b/src/services/stats.ts
@@ -1,0 +1,21 @@
+import { invoke } from "@tauri-apps/api/core";
+
+export interface WeeklyDayStat {
+  date: string;
+  focus_secs: number;
+  total_secs: number;
+}
+
+export interface TrendPoint {
+  date: string;
+  focus_pct: number;
+  focus_secs: number;
+}
+
+export async function getWeeklyReport(startDate: string): Promise<WeeklyDayStat[]> {
+  return invoke<WeeklyDayStat[]>("get_weekly_report", { startDate });
+}
+
+export async function getTrend(days: number): Promise<TrendPoint[]> {
+  return invoke<TrendPoint[]>("get_trend", { days });
+}

--- a/src/types/bindings.ts
+++ b/src/types/bindings.ts
@@ -18,9 +18,16 @@ export interface Activity {
   app_name: string;
   url: string | null;
   domain: string | null;
+  title: string | null;
   classification: Classification;
   started_at: string;
-  duration_secs: number;
+  duration_secs: number | null;
+}
+
+export interface SessionEvent {
+  session_id: string;
+  event_type: "start" | "end" | "end_incomplete";
+  timestamp: string;
 }
 
 export interface FocusStats {
@@ -60,6 +67,12 @@ export interface Reference {
   title: string;
   tags: string[];
   created_at: string;
+}
+
+export interface UpdateReferenceInput {
+  id: string;
+  title: string;
+  tags: string[];
 }
 
 export interface AppSettings {

--- a/src/types/bindings.ts
+++ b/src/types/bindings.ts
@@ -77,4 +77,11 @@ export interface UpdateReferenceInput {
 
 export interface AppSettings {
   retention_days: number;
+  shortcut_save_ref: string;
+}
+
+export interface ClassificationRule {
+  id: number;
+  domain: string;
+  category: string;
 }

--- a/src/types/bindings.ts
+++ b/src/types/bindings.ts
@@ -78,10 +78,19 @@ export interface UpdateReferenceInput {
 export interface AppSettings {
   retention_days: number;
   shortcut_save_ref: string;
+  shortcut_session_start: string;
+  shortcut_session_end: string;
 }
 
 export interface ClassificationRule {
   id: number;
   domain: string;
+  category: string;
+}
+
+export interface TitleRule {
+  id: number;
+  domain: string;
+  keyword: string;
   category: string;
 }

--- a/src/types/bindings.ts
+++ b/src/types/bindings.ts
@@ -94,3 +94,9 @@ export interface TitleRule {
   keyword: string;
   category: string;
 }
+
+export interface AppRule {
+  id: number;
+  app_name: string;
+  category: string;
+}


### PR DESCRIPTION
## Summary
- 설정 페이지에 타이틀 규칙 섹션 추가 (Quick Override로 저장된 규칙 조회/삭제)
- `getTitleRules`, `deleteTitleRule` 서비스 함수 추가
- `TitleRuleSettings` 컴포넌트 구현

## Test plan
- [ ] Quick Override로 타이틀 규칙 추가 후 설정 페이지에서 목록 확인
- [ ] 삭제 버튼으로 규칙 제거 확인

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)