### PR TITLE
[#33] Phase G: 시간대별 히트맵 및 요일 패턴 시각화

### DIFF
--- a/specs/001-activity-focus-tracker/tasks.md
+++ b/specs/001-activity-focus-tracker/tasks.md
@@ -354,16 +354,16 @@ title_rules (domain+keyword) → domain_rules (domain) → app_rules (app_name) 
 
 ### 백엔드
 
-- [ ] TG001 `src-tauri/src/commands/activity.rs`: `get_hourly_heatmap(days: u32)` 커맨드 — 시간(0~23) × 요일(0~6) 별 평균 Focus % 반환
-- [ ] TG002 `src-tauri/src/commands/activity.rs`: `get_weekday_stats(days: u32)` 커맨드 — 요일별 평균 Focus 시간(분) 반환
-- [ ] TG003 `src-tauri/src/lib.rs`: 커맨드 등록
+- [x] TG001 `src-tauri/src/commands/activity.rs`: `get_hourly_heatmap(days: u32)` 커맨드 — 시간(0~23) × 요일(0~6) 별 평균 Focus % 반환
+- [x] TG002 `src-tauri/src/commands/activity.rs`: `get_weekday_stats(days: u32)` 커맨드 — 요일별 평균 Focus 시간(분) 반환
+- [x] TG003 `src-tauri/src/lib.rs`: 커맨드 등록
 
 ### 프론트엔드
 
-- [ ] TG004 [P] `src/types/bindings.ts`: `HeatmapCell` (`hour`, `weekday`, `focus_pct`), `WeekdayStat` (`weekday`, `avg_focus_mins`) 인터페이스 추가
-- [ ] TG005 [P] `src/services/activity.ts`: `getHourlyHeatmap`, `getWeekdayStats` 추가
-- [ ] TG006 `src/components/Dashboard/PatternView.tsx`: 히트맵 그리드(24×7) + 요일별 바 차트 구현
-- [ ] TG007 `src/pages/Dashboard.tsx`: `패턴` 탭 추가 및 `PatternView` 연결
+- [x] TG004 [P] `src/types/bindings.ts`: `HeatmapCell` (`hour`, `weekday`, `focus_pct`), `WeekdayStat` (`weekday`, `avg_focus_mins`) 인터페이스 추가
+- [x] TG005 [P] `src/services/activity.ts`: `getHourlyHeatmap`, `getWeekdayStats` 추가
+- [x] TG006 `src/components/Dashboard/PatternView.tsx`: 히트맵 그리드(24×7) + 요일별 바 차트 구현
+- [x] TG007 `src/pages/Dashboard.tsx`: `패턴` 탭 추가 및 `PatternView` 연결
 
 ---
 

--- a/src-tauri/src/commands/activity.rs
+++ b/src-tauri/src/commands/activity.rs
@@ -183,6 +183,117 @@ pub async fn get_daily_focus_stats(
     })
 }
 
+/// 시간대(0~23) × 요일(0=Mon~6=Sun) 별 평균 Focus % 히트맵
+#[derive(Debug, serde::Serialize)]
+pub struct HeatmapCell {
+    pub hour: u8,
+    pub weekday: u8, // 0=Mon, 6=Sun
+    pub focus_pct: f64,
+}
+
+#[tauri::command]
+pub async fn get_hourly_heatmap(
+    state: State<'_, Mutex<AppState>>,
+    days: u32,
+) -> Result<Vec<HeatmapCell>, AppError> {
+    let pool = get_pool(&state);
+    let conn = pool.get().map_err(AppError::from)?;
+
+    // strftime('%w') = 0(Sun)~6(Sat) → 변환해서 0=Mon~6=Sun
+    let since = chrono::Utc::now().timestamp() - (days as i64 * 86400);
+    let mut stmt = conn
+        .prepare(
+            "SELECT
+               CAST(strftime('%H', datetime(started_at, 'unixepoch', 'localtime')) AS INTEGER) AS hour,
+               (CAST(strftime('%w', datetime(started_at, 'unixepoch', 'localtime')) AS INTEGER) + 6) % 7 AS weekday,
+               SUM(CASE WHEN classification = 'Focus' THEN COALESCE(duration_secs, 0) ELSE 0 END) AS focus_s,
+               SUM(COALESCE(duration_secs, 0)) AS total_s
+             FROM activities
+             WHERE started_at >= ?1 AND duration_secs > 0
+             GROUP BY hour, weekday",
+        )
+        .map_err(AppError::from)?;
+
+    let cells = stmt
+        .query_map(params![since], |row| {
+            let hour: u8 = row.get(0)?;
+            let weekday: u8 = row.get(1)?;
+            let focus_s: i64 = row.get(2)?;
+            let total_s: i64 = row.get(3)?;
+            Ok((hour, weekday, focus_s, total_s))
+        })
+        .map_err(AppError::from)?
+        .filter_map(|r| r.ok())
+        .map(|(hour, weekday, focus_s, total_s)| HeatmapCell {
+            hour,
+            weekday,
+            focus_pct: if total_s > 0 {
+                (focus_s as f64 / total_s as f64) * 100.0
+            } else {
+                0.0
+            },
+        })
+        .collect();
+
+    Ok(cells)
+}
+
+/// 요일별 평균 Focus 시간(분)
+#[derive(Debug, serde::Serialize)]
+pub struct WeekdayStat {
+    pub weekday: u8, // 0=Mon, 6=Sun
+    pub avg_focus_mins: f64,
+}
+
+#[tauri::command]
+pub async fn get_weekday_stats(
+    state: State<'_, Mutex<AppState>>,
+    days: u32,
+) -> Result<Vec<WeekdayStat>, AppError> {
+    let pool = get_pool(&state);
+    let conn = pool.get().map_err(AppError::from)?;
+    let since = chrono::Utc::now().timestamp() - (days as i64 * 86400);
+
+    let mut stmt = conn
+        .prepare(
+            "SELECT
+               (CAST(strftime('%w', datetime(started_at, 'unixepoch', 'localtime')) AS INTEGER) + 6) % 7 AS weekday,
+               strftime('%Y-%m-%d', datetime(started_at, 'unixepoch', 'localtime')) AS day,
+               SUM(CASE WHEN classification = 'Focus' THEN COALESCE(duration_secs, 0) ELSE 0 END) AS focus_s
+             FROM activities
+             WHERE started_at >= ?1 AND duration_secs > 0
+             GROUP BY weekday, day",
+        )
+        .map_err(AppError::from)?;
+
+    // (weekday → Vec<focus_secs per day>)
+    let mut map: std::collections::HashMap<u8, Vec<f64>> = std::collections::HashMap::new();
+    stmt.query_map(params![since], |row| {
+        let weekday: u8 = row.get(0)?;
+        let focus_s: i64 = row.get(2)?;
+        Ok((weekday, focus_s))
+    })
+    .map_err(AppError::from)?
+    .filter_map(|r| r.ok())
+    .for_each(|(wd, fs)| {
+        map.entry(wd).or_default().push(fs as f64 / 60.0);
+    });
+
+    let mut stats: Vec<WeekdayStat> = (0u8..7)
+        .map(|wd| {
+            let vals = map.get(&wd).cloned().unwrap_or_default();
+            let avg = if vals.is_empty() {
+                0.0
+            } else {
+                vals.iter().sum::<f64>() / vals.len() as f64
+            };
+            WeekdayStat { weekday: wd, avg_focus_mins: avg }
+        })
+        .collect();
+    stats.sort_by_key(|s| s.weekday);
+    Ok(stats)
+}
+
 /// 지금까지 추적된 고유 앱 이름 목록 반환 (앱 규칙 설정용)
 #[tauri::command]
 pub async fn get_tracked_apps(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -244,6 +244,8 @@ pub fn run() {
             commands::settings::get_app_rules,
             commands::settings::add_app_rule,
             commands::settings::delete_app_rule,
+            commands::activity::get_hourly_heatmap,
+            commands::activity::get_weekday_stats,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src/App.css
+++ b/src/App.css
@@ -2013,3 +2013,134 @@ body.dark-bg {
   border-color: #0a84ff;
   color: #0a84ff;
 }
+
+/* ── Pattern View (히트맵 + 요일 차트) ── */
+
+.pattern-view {
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+.pattern-section {}
+
+.pattern-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: #ebebf5;
+  margin: 0 0 14px;
+}
+
+.pattern-empty {
+  font-size: 12px;
+  color: #636366;
+  text-align: center;
+  padding: 24px 0;
+}
+
+/* 히트맵 */
+.heatmap-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.heatmap-row {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+}
+
+.heatmap-row--header {
+  margin-bottom: 2px;
+}
+
+.heatmap-label {
+  width: 20px;
+  font-size: 11px;
+  color: #636366;
+  text-align: right;
+  flex-shrink: 0;
+}
+
+.heatmap-hour-label {
+  flex: 1;
+  font-size: 9px;
+  color: #636366;
+  text-align: center;
+  min-width: 0;
+}
+
+.heatmap-cell {
+  flex: 1;
+  height: 14px;
+  border-radius: 2px;
+  min-width: 0;
+  cursor: default;
+  transition: opacity 0.1s;
+}
+
+.heatmap-cell:hover {
+  opacity: 0.8;
+}
+
+.heatmap-legend {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-top: 8px;
+  justify-content: flex-end;
+}
+
+.heatmap-legend__label {
+  font-size: 10px;
+  color: #636366;
+}
+
+.heatmap-legend__dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 2px;
+}
+
+/* 요일 바 차트 */
+.weekday-chart {
+  display: flex;
+  gap: 8px;
+  align-items: flex-end;
+  height: 120px;
+}
+
+.weekday-bar-col {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  height: 100%;
+}
+
+.weekday-bar-wrap {
+  flex: 1;
+  width: 100%;
+  display: flex;
+  align-items: flex-end;
+}
+
+.weekday-bar {
+  width: 100%;
+  background: rgba(48, 209, 88, 0.6);
+  border-radius: 3px 3px 0 0;
+  min-height: 2px;
+  transition: height 0.3s ease;
+}
+
+.weekday-bar-label {
+  font-size: 11px;
+  color: #8e8e93;
+}
+
+.weekday-bar-value {
+  font-size: 10px;
+  color: #636366;
+}

--- a/src/components/Dashboard/PatternView.tsx
+++ b/src/components/Dashboard/PatternView.tsx
@@ -1,0 +1,128 @@
+import { useEffect, useState } from "react";
+import type { HeatmapCell, WeekdayStat } from "../../types/bindings";
+import { getHourlyHeatmap, getWeekdayStats } from "../../services/activity";
+
+const WEEKDAYS = ["월", "화", "수", "목", "금", "토", "일"];
+const HOURS = Array.from({ length: 24 }, (_, i) => i);
+
+function focusColor(pct: number, hasData: boolean): string {
+  if (!hasData) return "rgba(255,255,255,0.04)";
+  if (pct >= 80) return "rgba(48,209,88,0.85)";
+  if (pct >= 60) return "rgba(48,209,88,0.55)";
+  if (pct >= 40) return "rgba(48,209,88,0.30)";
+  if (pct >= 20) return "rgba(255,159,10,0.35)";
+  return "rgba(255,69,58,0.30)";
+}
+
+export function PatternView() {
+  const [heatmap, setHeatmap] = useState<HeatmapCell[]>([]);
+  const [weekday, setWeekday] = useState<WeekdayStat[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    Promise.all([getHourlyHeatmap(30), getWeekdayStats(30)])
+      .then(([hm, wd]) => {
+        setHeatmap(hm);
+        setWeekday(wd);
+      })
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, []);
+
+  // (weekday, hour) → focus_pct 조회용 맵
+  const cellMap = new Map<string, number>();
+  heatmap.forEach((c) => cellMap.set(`${c.weekday}-${c.hour}`, c.focus_pct));
+
+  const maxFocusMins = Math.max(...weekday.map((s) => s.avg_focus_mins), 1);
+
+  if (loading) {
+    return <p className="dash-loading">로딩 중...</p>;
+  }
+
+  const hasAnyData = heatmap.length > 0;
+
+  return (
+    <div className="pattern-view">
+      {/* 히트맵 */}
+      <div className="pattern-section">
+        <h3 className="pattern-title">시간대별 집중도 (최근 30일)</h3>
+        {!hasAnyData ? (
+          <p className="pattern-empty">데이터가 충분하지 않습니다. 세션을 진행하면 패턴이 표시됩니다.</p>
+        ) : (
+          <>
+            <div className="heatmap-grid">
+              {/* 시간 축 헤더 */}
+              <div className="heatmap-row heatmap-row--header">
+                <div className="heatmap-label" />
+                {HOURS.map((h) => (
+                  <div key={h} className="heatmap-hour-label">
+                    {h % 3 === 0 ? `${h}시` : ""}
+                  </div>
+                ))}
+              </div>
+              {/* 요일별 행 */}
+              {WEEKDAYS.map((wd, wdIdx) => (
+                <div key={wdIdx} className="heatmap-row">
+                  <div className="heatmap-label">{wd}</div>
+                  {HOURS.map((h) => {
+                    const pct = cellMap.get(`${wdIdx}-${h}`);
+                    return (
+                      <div
+                        key={h}
+                        className="heatmap-cell"
+                        style={{ background: focusColor(pct ?? 0, pct !== undefined) }}
+                        title={pct !== undefined ? `${wd} ${h}시 — Focus ${Math.round(pct)}%` : "데이터 없음"}
+                      />
+                    );
+                  })}
+                </div>
+              ))}
+            </div>
+            {/* 범례 */}
+            <div className="heatmap-legend">
+              <span className="heatmap-legend__label">낮음</span>
+              {[0, 20, 40, 60, 80].map((p) => (
+                <div
+                  key={p}
+                  className="heatmap-legend__dot"
+                  style={{ background: focusColor(p, true) }}
+                />
+              ))}
+              <span className="heatmap-legend__label">높음</span>
+            </div>
+          </>
+        )}
+      </div>
+
+      {/* 요일별 평균 집중 시간 */}
+      <div className="pattern-section">
+        <h3 className="pattern-title">요일별 평균 집중 시간 (최근 30일)</h3>
+        {!hasAnyData ? (
+          <p className="pattern-empty">데이터가 충분하지 않습니다.</p>
+        ) : (
+          <div className="weekday-chart">
+            {weekday.map((s) => {
+              const pct = (s.avg_focus_mins / maxFocusMins) * 100;
+              const h = Math.floor(s.avg_focus_mins / 60);
+              const m = Math.round(s.avg_focus_mins % 60);
+              const label = h > 0 ? `${h}h ${m}m` : `${m}m`;
+              return (
+                <div key={s.weekday} className="weekday-bar-col">
+                  <div className="weekday-bar-wrap">
+                    <div
+                      className="weekday-bar"
+                      style={{ height: `${Math.max(pct, 2)}%` }}
+                      title={label}
+                    />
+                  </div>
+                  <span className="weekday-bar-label">{WEEKDAYS[s.weekday]}</span>
+                  <span className="weekday-bar-value">{s.avg_focus_mins > 0 ? label : "—"}</span>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -12,6 +12,7 @@ import { WeeklyReport } from "../components/Dashboard/WeeklyReport";
 import { TrendChart } from "../components/Dashboard/TrendChart";
 import { HabitInsights } from "../components/Dashboard/HabitInsights";
 import { ExportButton } from "../components/Dashboard/ExportButton";
+import { PatternView } from "../components/Dashboard/PatternView";
 
 function todayDateStr(): string {
   return new Date().toISOString().split("T")[0];
@@ -23,7 +24,7 @@ function shiftDate(dateStr: string, days: number): string {
   return d.toISOString().split("T")[0];
 }
 
-type Tab = "timeline" | "sites" | "score" | "refs" | "weekly" | "trend";
+type Tab = "timeline" | "sites" | "score" | "refs" | "weekly" | "trend" | "pattern";
 
 class TabErrorBoundary extends Component<{ children: ReactNode }, { error: Error | null }> {
   constructor(props: { children: ReactNode }) {
@@ -104,6 +105,7 @@ export function Dashboard() {
     { id: "score", label: "Focus Score" },
     { id: "weekly", label: "주간 리포트" },
     { id: "trend", label: "트렌드" },
+    { id: "pattern", label: "패턴" },
     { id: "refs", label: "References" },
   ];
 
@@ -186,6 +188,7 @@ export function Dashboard() {
                   onRefresh={() => getReferences().then(setRefs)}
                 />
               )}
+              {tab === "pattern" && <PatternView />}
             </>
           )}
         </TabErrorBoundary>

--- a/src/services/activity.ts
+++ b/src/services/activity.ts
@@ -1,5 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
-import type { Activity, DomainSummary, FocusMetrics, SessionEvent } from "../types/bindings";
+import type { Activity, DomainSummary, FocusMetrics, SessionEvent, HeatmapCell, WeekdayStat } from "../types/bindings";
 
 export async function getActivityTimeline(date: string): Promise<Activity[]> {
   return invoke<Activity[]>("get_activity_timeline", { date });
@@ -19,4 +19,12 @@ export async function getSessionEvents(date: string): Promise<SessionEvent[]> {
 
 export async function getTrackedApps(): Promise<string[]> {
   return invoke<string[]>("get_tracked_apps");
+}
+
+export async function getHourlyHeatmap(days: number = 30): Promise<HeatmapCell[]> {
+  return invoke<HeatmapCell[]>("get_hourly_heatmap", { days });
+}
+
+export async function getWeekdayStats(days: number = 30): Promise<WeekdayStat[]> {
+  return invoke<WeekdayStat[]>("get_weekday_stats", { days });
 }

--- a/src/types/bindings.ts
+++ b/src/types/bindings.ts
@@ -100,3 +100,14 @@ export interface AppRule {
   app_name: string;
   category: string;
 }
+
+export interface HeatmapCell {
+  hour: number;    // 0-23
+  weekday: number; // 0=Mon, 6=Sun
+  focus_pct: number;
+}
+
+export interface WeekdayStat {
+  weekday: number; // 0=Mon, 6=Sun
+  avg_focus_mins: number;
+}


### PR DESCRIPTION
## Summary
- `get_hourly_heatmap` / `get_weekday_stats` Tauri 커맨드 추가 (24×7 집중도 집계)
- `PatternView` 컴포넌트: 히트맵 그리드 + 요일별 평균 집중 시간 바 차트
- Dashboard에 `패턴` 탭 추가

## Test plan
- [ ] 패턴 탭 진입 시 히트맵 정상 렌더링
- [ ] 데이터 없을 때 빈 상태 메시지 표시
- [ ] 요일별 바 차트 비율 정확성 확인

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)