### PR TITLE
[#34] Phase H: 목표 달성 히스토리 및 스트릭

### DIFF
--- a/specs/001-activity-focus-tracker/tasks.md
+++ b/specs/001-activity-focus-tracker/tasks.md
@@ -373,19 +373,19 @@ title_rules (domain+keyword) → domain_rules (domain) → app_rules (app_name) 
 
 ### 백엔드
 
-- [ ] TH001 `src-tauri/migrations/V8__goal_history.sql`: `goal_history` 테이블 생성 (`date TEXT PK`, `target_secs INT`, `actual_secs INT`, `achieved BOOL`)
-- [ ] TH002 `src-tauri/src/services/goal.rs`: `record_daily_goal_result(date, target_secs, actual_secs)` 함수 추가
-- [ ] TH003 `src-tauri/src/commands/session.rs`: 세션 종료 시 `record_daily_goal_result` 호출
-- [ ] TH004 [P] `src-tauri/src/commands/activity.rs`: `get_goal_history(days: u32)` 커맨드 — 날짜별 달성 여부 목록 반환
-- [ ] TH005 `src-tauri/src/lib.rs`: 커맨드 등록
+- [x] TH001 `src-tauri/migrations/V8__goal_history.sql`: `goal_history` 테이블 생성 (`date TEXT PK`, `target_secs INT`, `actual_secs INT`, `achieved BOOL`)
+- [x] TH002 `src-tauri/src/services/goal.rs`: `record_daily_goal_result(date, target_secs, actual_secs)` 함수 추가
+- [x] TH003 `src-tauri/src/commands/session.rs`: 세션 종료 시 `record_daily_goal_result` 호출
+- [x] TH004 [P] `src-tauri/src/commands/activity.rs`: `get_goal_history(days: u32)` 커맨드 — 날짜별 달성 여부 목록 반환
+- [x] TH005 `src-tauri/src/lib.rs`: 커맨드 등록
 
 ### 프론트엔드
 
-- [ ] TH006 [P] `src/types/bindings.ts`: `GoalHistoryEntry` (`date`, `target_secs`, `actual_secs`, `achieved`) 인터페이스 추가
-- [ ] TH007 [P] `src/services/activity.ts`: `getGoalHistory(days)` 추가
-- [ ] TH008 `src/components/Dashboard/GoalHistory.tsx`: 최근 30일 달성 캘린더 + 연속 달성 스트릭 표시
-- [ ] TH009 `src/pages/Dashboard.tsx`: Focus Score 탭에 `GoalHistory` 컴포넌트 추가
-- [ ] TH010 `src/components/Dropdown/GoalProgress.tsx`: 연속 달성 일수 표시 추가
+- [x] TH006 [P] `src/types/bindings.ts`: `GoalHistoryEntry` (`date`, `target_secs`, `actual_secs`, `achieved`) 인터페이스 추가
+- [x] TH007 [P] `src/services/activity.ts`: `getGoalHistory(days)` 추가
+- [x] TH008 `src/components/Dashboard/GoalHistory.tsx`: 최근 30일 달성 캘린더 + 연속 달성 스트릭 표시
+- [x] TH009 `src/pages/Dashboard.tsx`: Focus Score 탭에 `GoalHistory` 컴포넌트 추가
+- [x] TH010 `src/components/Dropdown/GoalProgress.tsx`: 연속 달성 일수 표시 추가
 
 ---
 

--- a/src-tauri/migrations/V8__goal_history.sql
+++ b/src-tauri/migrations/V8__goal_history.sql
@@ -1,0 +1,7 @@
+-- V8: 일일 목표 달성 이력 테이블
+CREATE TABLE IF NOT EXISTS goal_history (
+    date        TEXT PRIMARY KEY,  -- YYYY-MM-DD
+    target_secs INTEGER NOT NULL,
+    actual_secs INTEGER NOT NULL,
+    achieved    INTEGER NOT NULL DEFAULT 0  -- BOOL: 0 or 1
+);

--- a/src-tauri/src/commands/activity.rs
+++ b/src-tauri/src/commands/activity.rs
@@ -294,6 +294,55 @@ pub async fn get_weekday_stats(
     Ok(stats)
 }
 
+/// 최근 N일 목표 달성 이력
+#[derive(Debug, serde::Serialize)]
+pub struct GoalHistoryEntry {
+    pub date: String,
+    pub target_secs: i64,
+    pub actual_secs: i64,
+    pub achieved: bool,
+}
+
+#[tauri::command]
+pub async fn get_goal_history(
+    state: State<'_, Mutex<AppState>>,
+    days: u32,
+) -> Result<Vec<GoalHistoryEntry>, AppError> {
+    let pool = get_pool(&state);
+    let conn = pool.get().map_err(AppError::from)?;
+    let since = chrono::Utc::now()
+        .format("%Y-%m-%d")
+        .to_string();
+    // days 이전 날짜 계산
+    let since_date = {
+        let d = chrono::Utc::now() - chrono::Duration::days(days as i64);
+        d.format("%Y-%m-%d").to_string()
+    };
+    let mut stmt = conn
+        .prepare(
+            "SELECT date, target_secs, actual_secs, achieved
+             FROM goal_history
+             WHERE date >= ?1
+             ORDER BY date ASC",
+        )
+        .map_err(AppError::from)?;
+    let rows = stmt
+        .query_map(params![since_date], |row| {
+            let achieved_int: i64 = row.get(3)?;
+            Ok(GoalHistoryEntry {
+                date: row.get(0)?,
+                target_secs: row.get(1)?,
+                actual_secs: row.get(2)?,
+                achieved: achieved_int != 0,
+            })
+        })
+        .map_err(AppError::from)?
+        .filter_map(|r| r.ok())
+        .collect();
+    let _ = since; // suppress unused warning
+    Ok(rows)
+}
+
 /// 지금까지 추적된 고유 앱 이름 목록 반환 (앱 규칙 설정용)
 #[tauri::command]
 pub async fn get_tracked_apps(

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -3,7 +3,7 @@ use tauri::{AppHandle, State};
 
 use crate::errors::AppError;
 use crate::models::session::{Session, SessionStatus};
-use crate::services::{metrics as metrics_svc, session as session_svc, tracker};
+use crate::services::{goal as goal_svc, metrics as metrics_svc, session as session_svc, tracker};
 use crate::state::app_state::AppState;
 
 #[derive(Debug, serde::Serialize)]
@@ -87,6 +87,20 @@ pub async fn end_session(state: State<'_, Mutex<AppState>>) -> Result<Session, A
     };
 
     let (started_at, ended_at) = session_svc::finish_session_record(&pool, &session_id)?;
+
+    // 세션 날짜의 목표 달성 결과 기록
+    {
+        let conn = pool.get().map_err(AppError::from)?;
+        let date = &unix_to_iso(started_at)[..10]; // YYYY-MM-DD
+        if let Ok(progress) = goal_svc::get_goal_progress(&conn, date) {
+            let _ = goal_svc::record_daily_goal_result(
+                &conn,
+                date,
+                progress.target_secs,
+                progress.actual_focus_secs,
+            );
+        }
+    }
 
     Ok(Session {
         id: session_id,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -246,6 +246,7 @@ pub fn run() {
             commands::settings::delete_app_rule,
             commands::activity::get_hourly_heatmap,
             commands::activity::get_weekday_stats,
+            commands::activity::get_goal_history,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/services/goal.rs
+++ b/src-tauri/src/services/goal.rs
@@ -105,6 +105,23 @@ pub fn get_goal_progress(conn: &Connection, date: &str) -> Result<GoalProgress, 
     })
 }
 
+/// 일별 목표 달성 결과를 goal_history 테이블에 기록 (upsert)
+pub fn record_daily_goal_result(
+    conn: &Connection,
+    date: &str,
+    target_secs: i64,
+    actual_secs: i64,
+) -> Result<(), AppError> {
+    let achieved = if actual_secs >= target_secs { 1 } else { 0 };
+    conn.execute(
+        "INSERT OR REPLACE INTO goal_history (date, target_secs, actual_secs, achieved)
+         VALUES (?1, ?2, ?3, ?4)",
+        params![date, target_secs, actual_secs, achieved],
+    )
+    .map_err(AppError::from)?;
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/App.css
+++ b/src/App.css
@@ -2144,3 +2144,76 @@ body.dark-bg {
   font-size: 10px;
   color: #636366;
 }
+
+/* Goal History */
+.score-section {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.goal-history {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.goal-history__stats {
+  display: flex;
+  gap: 24px;
+}
+
+.goal-history__stat {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+}
+
+.goal-history__stat-value {
+  font-size: 22px;
+  font-weight: 600;
+  color: #fff;
+}
+
+.goal-history__stat-label {
+  font-size: 11px;
+  color: #8e8e93;
+}
+
+.goal-history__calendar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.goal-history__day {
+  width: 36px;
+  height: 36px;
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.06);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: default;
+}
+
+.goal-history__day--achieved {
+  background: rgba(48, 209, 88, 0.3);
+}
+
+.goal-history__day-label {
+  font-size: 10px;
+  color: #8e8e93;
+}
+
+.goal-history__day--achieved .goal-history__day-label {
+  color: #30d158;
+}
+
+/* Streak badge in GoalProgress */
+.goal-progress__streak {
+  font-size: 12px;
+  color: #ffd60a;
+  font-weight: 600;
+}

--- a/src/components/Dashboard/GoalHistory.tsx
+++ b/src/components/Dashboard/GoalHistory.tsx
@@ -1,0 +1,76 @@
+import { useEffect, useState } from "react";
+import type { GoalHistoryEntry } from "../../types/bindings";
+import { getGoalHistory } from "../../services/activity";
+
+function formatMins(secs: number): string {
+  const m = Math.floor(secs / 60);
+  if (m < 60) return `${m}m`;
+  const h = Math.floor(m / 60);
+  const rm = m % 60;
+  return rm > 0 ? `${h}h ${rm}m` : `${h}h`;
+}
+
+export function GoalHistory() {
+  const [history, setHistory] = useState<GoalHistoryEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    getGoalHistory(30)
+      .then(setHistory)
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) return <p className="dash-loading">로딩 중...</p>;
+  if (history.length === 0) {
+    return (
+      <p className="pattern-empty">
+        아직 목표 달성 기록이 없습니다. 세션을 완료하면 여기에 표시됩니다.
+      </p>
+    );
+  }
+
+  // 연속 달성 일수 계산 (최근부터 역순으로 연속된 달성 수)
+  const sorted = [...history].sort((a, b) => b.date.localeCompare(a.date));
+  let streak = 0;
+  for (const entry of sorted) {
+    if (entry.achieved) streak++;
+    else break;
+  }
+
+  const total = history.length;
+  const achieved = history.filter((e) => e.achieved).length;
+
+  return (
+    <div className="goal-history">
+      <div className="goal-history__stats">
+        <div className="goal-history__stat">
+          <span className="goal-history__stat-value" style={{ color: "#ffd60a" }}>{streak}일</span>
+          <span className="goal-history__stat-label">연속 달성</span>
+        </div>
+        <div className="goal-history__stat">
+          <span className="goal-history__stat-value">{achieved}/{total}</span>
+          <span className="goal-history__stat-label">달성 / 전체</span>
+        </div>
+        <div className="goal-history__stat">
+          <span className="goal-history__stat-value">
+            {total > 0 ? Math.round((achieved / total) * 100) : 0}%
+          </span>
+          <span className="goal-history__stat-label">달성률</span>
+        </div>
+      </div>
+
+      <div className="goal-history__calendar">
+        {history.map((entry) => (
+          <div
+            key={entry.date}
+            className={`goal-history__day${entry.achieved ? " goal-history__day--achieved" : ""}`}
+            title={`${entry.date} — ${formatMins(entry.actual_secs)} / ${formatMins(entry.target_secs)}${entry.achieved ? " ✓" : ""}`}
+          >
+            <span className="goal-history__day-label">{entry.date.slice(5)}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/Dropdown/GoalProgress.tsx
+++ b/src/components/Dropdown/GoalProgress.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { getDailyGoal, getGoalProgress, setDailyGoal, type GoalProgress as GoalProgressData } from "../../services/goal";
+import { getGoalHistory } from "../../services/activity";
 
 const PRESET_HOURS = [1, 2, 3, 4, 6];
 
@@ -14,10 +15,20 @@ export function GoalProgress() {
   const [progress, setProgress] = useState<GoalProgressData | null>(null);
   const [editing, setEditing] = useState(false);
   const [selectedHours, setSelectedHours] = useState(2);
+  const [streak, setStreak] = useState(0);
 
   useEffect(() => {
     getGoalProgress().then(setProgress);
     getDailyGoal().then((g) => setSelectedHours(Math.round(g.target_secs / 3600)));
+    getGoalHistory(30).then((hist) => {
+      const sorted = [...hist].sort((a, b) => b.date.localeCompare(a.date));
+      let s = 0;
+      for (const e of sorted) {
+        if (e.achieved) s++;
+        else break;
+      }
+      setStreak(s);
+    }).catch(() => {});
   }, []);
 
   const handleSave = async () => {
@@ -35,7 +46,14 @@ export function GoalProgress() {
   return (
     <div className="goal-progress">
       <div className="goal-progress__header">
-        <span className="goal-progress__label">오늘 목표</span>
+        <span className="goal-progress__label">
+          오늘 목표
+          {streak > 0 && (
+            <span className="goal-progress__streak" title={`${streak}일 연속 달성`}>
+              {" "}🔥 {streak}
+            </span>
+          )}
+        </span>
         <button
           className="goal-progress__edit-btn"
           onClick={() => setEditing((v) => !v)}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -13,6 +13,7 @@ import { TrendChart } from "../components/Dashboard/TrendChart";
 import { HabitInsights } from "../components/Dashboard/HabitInsights";
 import { ExportButton } from "../components/Dashboard/ExportButton";
 import { PatternView } from "../components/Dashboard/PatternView";
+import { GoalHistory } from "../components/Dashboard/GoalHistory";
 
 function todayDateStr(): string {
   return new Date().toISOString().split("T")[0];
@@ -163,7 +164,12 @@ export function Dashboard() {
             <>
               {tab === "timeline" && <ActivityTimeline activities={activities} sessionEvents={sessionEvents} />}
               {tab === "sites" && <TopSites sites={sites} />}
-              {tab === "score" && <FocusScore metrics={metrics} />}
+              {tab === "score" && (
+                <div className="score-section">
+                  <FocusScore metrics={metrics} />
+                  <GoalHistory />
+                </div>
+              )}
               {tab === "weekly" && (
                 <div className="weekly-section">
                   <div className="weekly-section__block">

--- a/src/services/activity.ts
+++ b/src/services/activity.ts
@@ -1,5 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
-import type { Activity, DomainSummary, FocusMetrics, SessionEvent, HeatmapCell, WeekdayStat } from "../types/bindings";
+import type { Activity, DomainSummary, FocusMetrics, GoalHistoryEntry, SessionEvent, HeatmapCell, WeekdayStat } from "../types/bindings";
 
 export async function getActivityTimeline(date: string): Promise<Activity[]> {
   return invoke<Activity[]>("get_activity_timeline", { date });
@@ -27,4 +27,8 @@ export async function getHourlyHeatmap(days: number = 30): Promise<HeatmapCell[]
 
 export async function getWeekdayStats(days: number = 30): Promise<WeekdayStat[]> {
   return invoke<WeekdayStat[]>("get_weekday_stats", { days });
+}
+
+export async function getGoalHistory(days: number = 30): Promise<GoalHistoryEntry[]> {
+  return invoke<GoalHistoryEntry[]>("get_goal_history", { days });
 }

--- a/src/types/bindings.ts
+++ b/src/types/bindings.ts
@@ -111,3 +111,10 @@ export interface WeekdayStat {
   weekday: number; // 0=Mon, 6=Sun
   avg_focus_mins: number;
 }
+
+export interface GoalHistoryEntry {
+  date: string;       // YYYY-MM-DD
+  target_secs: number;
+  actual_secs: number;
+  achieved: boolean;
+}


### PR DESCRIPTION
## Summary
- `V8__goal_history.sql` 마이그레이션: `goal_history` 테이블 추가
- 세션 종료 시 자동으로 오늘 목표 달성 결과 기록
- `get_goal_history(days)` Tauri 커맨드 추가
- `GoalHistory` 컴포넌트: 최근 30일 달성 캘린더 + 스트릭/달성률 표시
- Focus Score 탭에 GoalHistory 추가
- 드롭다운 GoalProgress에 🔥 연속 달성 일수 배지 추가

## Test plan
- [ ] 세션 종료 후 goal_history 테이블에 레코드 기록 확인
- [ ] Focus Score 탭에서 달성 캘린더 렌더링 확인
- [ ] 드롭다운에서 스트릭 배지 표시 확인
- [ ] 데이터 없을 때 빈 상태 메시지 표시 확인

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)